### PR TITLE
Fixed #53

### DIFF
--- a/blocks.js
+++ b/blocks.js
@@ -3443,16 +3443,19 @@ ReporterBlockMorph.prototype.getSlotSpec = function () {
 // ReporterBlockMorph events
 
 ReporterBlockMorph.prototype.mouseClickLeft = function (pos) {
+    var isRing;
     if (this.parent instanceof BlockInputFragmentMorph) {
         return this.parent.mouseClickLeft();
     }
     if (this.parent instanceof TemplateSlotMorph) {
+        isRing = this.parent.parent && this.parent.parent.parent &&
+            this.parent.parent.parent instanceof RingMorph;
         new DialogBoxMorph(
             this,
             this.setSpec,
             this
         ).prompt(
-            "Input name",
+            isRing ? "Input name" : "Script variable name",
             this.blockSpec,
             this.world()
         );


### PR DESCRIPTION
Renaming a script variable presents a dialog entitled "Script variable name," while renaming a ring input still presents a dialog entitled "Input name."
