### PR TITLE
Fixed #59

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -1989,7 +1989,7 @@ IDE_Morph.prototype.projectMenu = function () {
 
     menu.addItem(
         shiftClicked ?
-                'Export project as plain text ...' : 'Export project...',
+                'Export project as plain text...' : 'Export project...',
         function () {
             if (myself.projectName) {
                 myself.exportProject(myself.projectName, shiftClicked);
@@ -2004,7 +2004,7 @@ IDE_Morph.prototype.projectMenu = function () {
     );
 
     menu.addItem(
-        'Export blocks ...',
+        'Export blocks...',
         function () {myself.exportGlobalBlocks(); },
         'show global custom block definitions as XML\nin a new browser window'
     );

--- a/lang-cs.js
+++ b/lang-cs.js
@@ -633,13 +633,13 @@ SnapTranslator.dict.cs = {
     'file menu import hint':
         'Načíst exportovaný projekt, '
             + 'knihovnu bloků, kostýmy nebo zvuky',
-    'Export project as plain text ...':
+    'Export project as plain text...':
         'Exportovat projekt jako prostý text...',
     'Export project...':
         'Exportovat projekt...',
     'show project data as XML\nin a new browser window':
         'zobrazit data projektu jako xml  XML\n v novém okně prohlížeče',
-    'Export blocks ...':
+    'Export blocks...':
         'Exportovat bloky...',
     'show global custom block definitions as XML\nin a new browser window':
         'Zobrazit definici vlastních bloků jako\nXML v novém okně prohlížeče',

--- a/lang-de.js
+++ b/lang-de.js
@@ -637,13 +637,13 @@ SnapTranslator.dict.de = {
         'l\u00e4dt ein exportiertes Projekt,\neine Bibliothek mit '
             + 'Bl\u00f6cken\n'
             + 'ein Kost\u00fcm oder einen Klang',
-    'Export project as plain text ...':
+    'Export project as plain text...':
         'Projekt als normalen Text exportieren...',
     'Export project...':
         'Projekt exportieren...',
     'show project data as XML\nin a new browser window':
         'zeigt das Projekt als XML\nin einem neuen Browserfenster an',
-    'Export blocks ...':
+    'Export blocks...':
         'Bl\u00f6cke exportieren...',
     'show global custom block definitions as XML\nin a new browser window':
         'zeigt globale Benutzerblockdefinitionen\nals XML im Browser an',

--- a/lang-eo.js
+++ b/lang-eo.js
@@ -606,14 +606,14 @@ SnapTranslator.dict.eo = {
         'Importi...',
     'file menu import hint':
         'elŝutu dosieron kun blokoj sonoj aŭ kostumoj',
-    'Export project as plain text ...':
-        'Eksporti projekton en plata teksta formo ...',
+    'Export project as plain text...':
+        'Eksporti projekton en plata teksta formo...',
     'Export project...':
         'Eksporti projekton...',
     'show project data as XML\nin a new browser window':
         'prezenti projekton kiel XML\nen nova fenestro de retumilo',
-    'Export blocks ...':
-        'Eksporti blokojn ...',
+    'Export blocks...':
+        'Eksporti blokojn...',
     'show global custom block definitions as XML\nin a new browser window':
         'prezenti mallokajn difinojn de propraj blokoj kiel XML\nen nova fenestro de retumilo',
     'Delete Project':

--- a/lang-es.js
+++ b/lang-es.js
@@ -619,13 +619,13 @@ SnapTranslator.dict.es = {
         'Importar...',
     'file menu import hint':
         'men\u00FA de archivo de importaci\u00F3n indirecta',
-    'Export project as plain text ...':
+    'Export project as plain text...':
         'Exportar proyecto como texto...',
     'Export project...':
         'Exportar proyecto...',
     'show project data as XML\nin a new browser window':
         'mostrar informaci\u00F3n de proyecto como XML\nen una nueva ventana',
-    'Export blocks ...':
+    'Export blocks...':
         'Exportar bloques...',
     'show global custom block definitions as XML\nin a new browser window':
         'mostrar definiciones de bloques globales personalizados como XML\nen una nueva ventana',

--- a/lang-fr.js
+++ b/lang-fr.js
@@ -587,7 +587,7 @@ SnapTranslator.dict.fr = {
    // menus
     // snap menu
     'About...':
-        'A propos de Snap! ...',
+        'A propos de Snap!...',
     'Snap! website':
         'Snap! le site web',
     'Download source':
@@ -618,13 +618,13 @@ SnapTranslator.dict.fr = {
         'importer un projet export\u00E9,\nune biblioth\u00E8que de '
             + 'blocs\n'
             + 'un costume ou un son',
-    'Export project as plain text ...':
+    'Export project as plain text...':
         'Exporter le projet comme texte...',
     'Export project...':
         'Exporter le projet...',
     'show project data as XML\nin a new browser window':
         'ouvrir le projet au format XML\ndans une nouvelle fen\u00EAtre de votre navigateur',
-    'Export blocks ...':
+    'Export blocks...':
         'Exporter les blocs ',
     'show global custom block definitions as XML\nin a new browser window':
         'montrer les d\u00E9finitions de bloc global personnalis\u00E9 au format XML \ndans une nouvelle fen\u00EAtre de navigateur',

--- a/lang-it.js
+++ b/lang-it.js
@@ -634,13 +634,13 @@ SnapTranslator.dict.it = {
         'carica un file di progetto,\nuna libreria di blocchi,'
             + '\nun costume o un suono esportati'
             + '\n\nNon supportato da tutti i browser',
-    'Export project as plain text ...':
+    'Export project as plain text...':
         'Esporta il progetto come un file di testo...',
     'Export project...':
         'Esporta il progetto...',
     'show project data as XML\nin a new browser window':
         'mostra i dati del progetto in formato XML\nin una nuova finestra del browser',
-    'Export blocks ...':
+    'Export blocks...':
         'Esporta blocchi...',
     'show global custom block definitions as XML\nin a new browser window':
         'mostra in formato XML le definizione dei nuovi blocchi\nin una nuova finestra del browser',

--- a/lang-ja.js
+++ b/lang-ja.js
@@ -632,13 +632,13 @@ SnapTranslator.dict.ja = {
         'チェックするとレポーターをドラッグ&ドロップするとき\n'
 		+ '空のレポーターにフォーカスします\n\n'
 		+ 'いくつかのブラウザーではサポートされません',
-    'Export project as plain text ...':
+    'Export project as plain text...':
         'テキストファイルとしてプロジェクトを書き出す...',
     'Export project...':
         'プロジェクトを書き出す...',
     'show project data as XML\nin a new browser window':
         'プロジェクトのデータをXMLとして\nブラウザの新しいウインドウに表示する',
-    'Export blocks ...':
+    'Export blocks...':
         'ブロックを書き出す...',
     'show global custom block definitions as XML\nin a new browser window':
         'グローバルカスタムブロックの定義をXMLとして\nブラウザの新しいウインドウに表示する',

--- a/lang-ja_HIRA.js
+++ b/lang-ja_HIRA.js
@@ -632,13 +632,13 @@ SnapTranslator.dict.ja_HIRA = {
         'チェックするとレポーターをドラッグ&ドロップするとき\n'
 		+ 'そらのレポーターにフォーカスします\n\n'
 		+ 'いくつかのブラウザーではサポートされません',
-    'Export project as plain text ...':
+    'Export project as plain text...':
         'テキストファイルとしてプロジェクトをかきだす...',
     'Export project...':
         'プロジェクトをかきだす...',
     'show project data as XML\nin a new browser window':
         'プロジェクトのデータをXMLとして\nブラウザのあたらしいウインドウにひょうじする',
-    'Export blocks ...':
+    'Export blocks...':
         'ブロックをかきだす...',
     'show global custom block definitions as XML\nin a new browser window':
         'グローバルカスタムブロックのていぎをXMLとして\nブラウザのあたらしいウインドウにひょうじする',

--- a/lang-ko.js
+++ b/lang-ko.js
@@ -618,13 +618,13 @@ SnapTranslator.dict.ko = {
         '내보낸 프로젝트 파일, 블록 라이브러리\n'
 		+ '스프라이트 모양 또는 소리를 가져옵니다.\n\n'
 		+ '일부 웹브라우저에서는 지원되지 않습니다.',
-    'Export project as plain text ...':
+    'Export project as plain text...':
         '프로젝트를 텍스트 파일로 내보내기...',
     'Export project...':
         '프로젝트 내보내기...',
     'show project data as XML\nin a new browser window':
         '프로젝트 데이터를\n새로운 윈도우에 XML 형태로 보여주기',
-    'Export blocks ...':
+    'Export blocks...':
         '블록 내보내기...',
     'show global custom block definitions as XML\nin a new browser window':
         '새롭게 정의한 전역 블록 데이터를\n새로운 윈도우에 XML 형태로 보여주기',

--- a/lang-pt.js
+++ b/lang-pt.js
@@ -639,13 +639,13 @@ SnapTranslator.dict.pt = {
         'Importar para este projecto\num projecto exportado,\n'
             + 'uma biblioteca de blocos,\n'
             + 'um traje ou um som.',
-    'Export project as plain text ...':
+    'Export project as plain text...':
         'Exportar este projecto como texto simples…',
     'Export project...':
         'Exportar este projecto…',
     'show project data as XML\nin a new browser window':
         'Mostrar os dados do projecto no\nformato XML numa nova janela do navegador.',
-    'Export blocks ...':
+    'Export blocks...':
         'Exportar blocos deste projecto…',
     'show global custom block definitions as XML\nin a new browser window':
         'Mostrar as definições de blocos\npersonalizados globais no formato\nXML numa nova janela do navegador.',

--- a/lang-ru.js
+++ b/lang-ru.js
@@ -613,13 +613,13 @@ SnapTranslator.dict.ru = {
         'Импорт...',
     'file menu import hint':
         'загрузить экспортированный проект\nили библиотеку блоков, маску или звук',
-    'Export project as plain text ...':
+    'Export project as plain text...':
         'Экспорт проект как текстовый файл...',
     'Export project...':
         'Экспорт проект...',
     'show project data as XML\nin a new browser window':
         'представить проектные данные как XML\nв новом окне браузера',
-    'Export blocks ...':
+    'Export blocks...':
         'Экспорт блоки...',
     'show global custom block definitions as XML\nin a new browser window':
         'представить определения глобальных пользовательских блоков как XML\nв новом окне браузера',

--- a/lang-si.js
+++ b/lang-si.js
@@ -610,13 +610,13 @@ SnapTranslator.dict.si = {
         'Nalaganje izvo\u017Eenega projekta,\nknji\u017Enice z '
             + 'bloki\n'
             + 'obleko ali zvokom',
-    'Export project as plain text ...':
+    'Export project as plain text...':
         'Izvozi projekt kot navadno besedilo...',
     'Export project...':
         'Izvozi projekt...',
     'show project data as XML\nin a new browser window':
         'Prikaz projekta kot XML\nv novem oknu brkljalnika',
-    'Export blocks ...':
+    'Export blocks...':
         'Izvozi bloke',
     'show global custom block definitions as XML\nin a new browser window':
         'Prikaz definicij globalnih lastnih blokov kot XML\nv novem oknu brkljalnika',

--- a/lang-zh.js
+++ b/lang-zh.js
@@ -636,13 +636,13 @@ SnapTranslator.dict.zh = {
         '当你拖动到系统，注意查看检查报告\n'
 		+ '要注意检查报告为空\n\n'
 		+ '有一些浏览器不支持这一功能',
-    'Export project as plain text ...':
+    'Export project as plain text...':
         '纯文本格式导出项目...',
     'Export project...':
         '导出项目...',
     'show project data as XML\nin a new browser window':
         '新浏览窗以XML格式显示项目',
-    'Export blocks ...':
+    'Export blocks...':
         '导出程序块...',
     'show global custom block definitions as XML\nin a new browser window':
         '新浏览窗以XML格式显示全局自定义程序块',


### PR DESCRIPTION
The "Export tools..." and "Export project as plain text..." menu items no longer have a space before their trailing ellipses.
