### PR TITLE
Fixed #73

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -2902,6 +2902,7 @@ IDE_Morph.prototype.userSetBlocksScale = function () {
 
     sample = new FrameMorph();
     sample.texture = 'scriptsPaneTexture.gif';
+    sample.acceptsDrops = false;
     sample.setExtent(new Point(250, 180));
     scrpt.setPosition(sample.position().add(10));
     sample.add(scrpt);


### PR DESCRIPTION
The "Zoom blocks" dialog no longer accepts dropped sprites, watchers, dialogs, blocks, etc.
