### PR TITLE
Duplicate join words block in tools.xml

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -132,7 +132,7 @@ IDE_Morph.prototype.setDefaultDesign = function () {
 };
 
 IDE_Morph.prototype.setFlatDesign = function () {
-    MorphicPreferences.isFlat = false;
+    MorphicPreferences.isFlat = true;
     SpriteMorph.prototype.paletteColor = new Color(255, 255, 255);
     SpriteMorph.prototype.paletteTextColor = new Color(70, 70, 70);
     StageMorph.prototype.paletteTextColor
@@ -159,7 +159,7 @@ IDE_Morph.prototype.setFlatDesign = function () {
     ];
     IDE_Morph.prototype.appModeColor = IDE_Morph.prototype.frameColor;
     IDE_Morph.prototype.scriptsPaneTexture = null;
-    IDE_Morph.prototype.padding = 5;
+    IDE_Morph.prototype.padding = 1;
 
     SpriteIconMorph.prototype.labelColor
         = IDE_Morph.prototype.buttonLabelColor;


### PR DESCRIPTION
Snap! by default now lets you expand the built in join block to have any number of items. This seems to make the join words block included in tools redundant and unnecessary, so it's been removed.
