### PR TITLE
Add useful headers to HTTP block

### DIFF
--- a/threads.js
+++ b/threads.js
@@ -1730,6 +1730,9 @@ Process.prototype.reportURL = function (url) {
     if (!this.httpRequest) {
         this.httpRequest = new XMLHttpRequest();
         this.httpRequest.open("GET", 'http://' + url, true);
+        this.httpRequest.setRequestHeader("X-Requested-With",
+                                          "XMLHttpRequest");
+        this.httpRequest.setRequestHeader("X-Application", "Snap! 4.0");
         this.httpRequest.send(null);
     } else if (this.httpRequest.readyState === 4) {
         response = this.httpRequest.responseText;


### PR DESCRIPTION
These would be really useful to have for writing extensions, so we can differentiate between Snap! and a browser.

Currently there's no foolproof way of doing this: using `User-Agent` or `Accept` headers doesn't work because they match the ones sent by the browser. And using the `Referer` or `Origin` headers could get tripped up by local copies of Snap!.
