### PR TITLE
Fixes issue #310 - play note block fails on Firefox 

### DIFF
--- a/objects.js
+++ b/objects.js
@@ -5647,17 +5647,20 @@ Note.prototype.setupContext = function () {
     if (this.audioContext) { return; }
     var AudioContext = (function () {
         // cross browser some day?
-        return window.AudioContext ||
+        var ctx = window.AudioContext ||
             window.mozAudioContext ||
             window.msAudioContext ||
             window.oAudioContext ||
             window.webkitAudioContext;
+        if (!ctx.prototype.hasOwnProperty('createGain'))
+            ctx.prototype.createGain = ctx.prototype.createGainNode;
+        return ctx;
     }());
     if (!AudioContext) {
         throw new Error('Web Audio API is not supported\nin this browser');
     }
     Note.prototype.audioContext = new AudioContext();
-    Note.prototype.gainNode = Note.prototype.audioContext.createGainNode();
+    Note.prototype.gainNode = Note.prototype.audioContext.createGain();
     Note.prototype.gainNode.gain.value = 0.25; // reduce volume by 1/4
 };
 
@@ -5665,17 +5668,21 @@ Note.prototype.setupContext = function () {
 
 Note.prototype.play = function () {
     this.oscillator = this.audioContext.createOscillator();
+    if (!this.oscillator.start)
+        this.oscillator.start = this.oscillator.noteOn;
+    if (!this.oscillator.stop)
+        this.oscillator.stop = this.oscillator.noteOff;
     this.oscillator.type = 0;
     this.oscillator.frequency.value =
         Math.pow(2, (this.pitch - 69) / 12) * 440;
     this.oscillator.connect(this.gainNode);
     this.gainNode.connect(this.audioContext.destination);
-    this.oscillator.noteOn(0); // deprecated, renamed to start()
+    this.oscillator.start(0);
 };
 
 Note.prototype.stop = function () {
     if (this.oscillator) {
-        this.oscillator.noteOff(0); // deprecated, renamed to stop()
+        this.oscillator.stop(0);
         this.oscillator = null;
     }
 };


### PR DESCRIPTION
Fails due to use of deprecated WebAudio names. The fix uses the correct names and monkey-patches browsers that use the old ones.
