### PR TITLE
better error message when importing (into a variable)

### DIFF
--- a/objects.js
+++ b/objects.js
@@ -6466,11 +6466,11 @@ WatcherMorph.prototype.userMenu = function () {
                         document.body.removeChild(inp);
                         ide.filePicker = null;
                         if (inp.files.length > 0) {
-                            for (i = 0; i < inp.files.length; i += 1) {
-                                file = inp.files[i];
-                                if (file.type.indexOf("text") === 0) {
-                                    readText(file);
-                                }
+                            file = inp.files[inp.files.length - 1];
+                            if (file.type.indexOf("text") === 0) {
+                                readText(file);
+                            } else {
+                            	ide.inform("Unable to import", "Snap! can only import \"text\" files.\n You selected a file of type \"" + file.type + "\".");
                             }
                         }
                     },


### PR DESCRIPTION
Students were flumoxed when they couldn't import into a variable from a .csv file on windows (snap silently did nothing).  If they simply changed the extension to .txt things worked. I looked at OKaying the .csv type in snap, but (on windows) the file was "application/ms ..." which was ugly and maybe not distinguishable from a regular excel file!  

This just adds an error message. 

Additionally, I had it read only the last file if multiple were picked, since reading multiple files seemed a waste and made error reporting trickier.  (On windows you can't pick more than one). 

This fix removes a "feature", though, where Snap would do something useful if both text files and non-text files were picked -- this fix only ever looks at the last file in the pick list.
