### PR TITLE
Specify an encoding for variable export

### DIFF
--- a/objects.js
+++ b/objects.js
@@ -6339,7 +6339,7 @@ WatcherMorph.prototype.userMenu = function () {
                 'export...',
                 function () {
                     window.open(
-                        'data:text/plain,' +
+                        'data:text/plain;charset=utf-8,' +
                             encodeURIComponent(this.currentValue.toString())
                     );
                 }


### PR DESCRIPTION
Uses the correct [encoding for data URIs](https://en.wikipedia.org/wiki/Data_URI_scheme#Format) when right-clicking on a variable and choosing "export...".

Before/after:
![screenshot 2014-04-26 01 10 44](https://cloud.githubusercontent.com/assets/639289/2806934/66f5afc4-ccd7-11e3-9acf-e8cfdc0199ed.png)

I believe UTF-8 is the charset [encodeURIComponent](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent) uses.
