### PR TITLE
add stage height, width accessors to the OF block

### DIFF
--- a/blocks.js
+++ b/blocks.js
@@ -6616,17 +6616,13 @@ InputSlotMorph.prototype.attributesMenu = function () {
             'direction' : ['direction'],
             'costume #' : ['costume #'],
             'costume name' : ['costume name'],
-            'size' : ['size'],
-            '~~' : null, // ~~ prevents conflicts below
-            'pen size' : ['pen size'],
-            'pen color' : ['pen color'],
-            'pen shade' : ['pen shade'],
+            'size' : ['size']
         };
     } else { // the stage
         dict = {
             'costume #' : ['costume #'],
             'costume name' : ['costume name'],
-            '~~' : null,
+            '~~' : null, // ~~ prevents conflicts with ~ below.
             'stage height' : ['stage height'],
             'stage width' : ['stage width']
         };

--- a/threads.js
+++ b/threads.js
@@ -2446,12 +2446,6 @@ Process.prototype.reportAttributeOf = function (attribute, name) {
                                 : localize('Empty');
             case 'size':
                 return thatObj.getScale ? thatObj.getScale() : '';
-            case 'pen size':
-                return thatObj.penSize ? thatObj.penSize() : '';
-            case 'pen color':
-                return thatObj.getHue ? thatObj.getHue() : '';
-            case 'pen shade':
-                return thatObj.getBrightness ? thatObj.getBrightness() : '';
             case 'stage width':
                 return thatObj.width ? thatObj.width() : '';
             case 'stage height':


### PR DESCRIPTION
This fixes #325, and somewhat makes #329 easier (Dan was asking for watchers).

I don't think there's much to this, but i do wonder if there should be a separator in the drop down menu between the costume options and the new options?
