### PR TITLE
tools now pointing locally

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -2365,7 +2365,7 @@ IDE_Morph.prototype.projectMenu = function () {
         function () {
             myself.droppedText(
                 myself.getURL(
-                    'http://snap.berkeley.edu/snapsource/tools.xml'
+                    'tools.xml'
                 ),
                 'tools'
             );


### PR DESCRIPTION
This is important - why even have tools.xml as part of the Snap repository unless Snap is pointing to their own tools.xml?
