### PR TITLE
GUI: Limit Zoom blocks scale to max of 12; fixes #255

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -3484,7 +3484,7 @@ IDE_Morph.prototype.userSetBlocksScale = function () {
         c.nestedBlock(scrpt);
     */
         scrpt.blockSequence().forEach(function (block) {
-            block.setScale(num);
+            block.setScale(num < 12 ? num : 12);
             block.drawNew();
             block.setSpec(block.blockSpec);
         });
@@ -3493,7 +3493,8 @@ IDE_Morph.prototype.userSetBlocksScale = function () {
     new DialogBoxMorph(
         null,
         function (num) {
-            myself.setBlocksScale(num);
+            // Ensure BlocksScale is always < 12 to prevent crashes
+            myself.setBlocksScale(num < 12 ? num : 12);
         }
     ).withKey('zoomBlocks').prompt(
         'Zoom blocks',


### PR DESCRIPTION
Simple and easy fix. :)

Even if you type '129999999999' in the display box, it won't draw blocks larger than 12x scale. 

(Of course, someone who really wanted could always modify the localStorage setting, but then s/he is asking for trouble!)
