### PR TITLE
Remove nop help menu items from context menus

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -1857,7 +1857,7 @@ IDE_Morph.prototype.removeSprite = function (sprite) {
 
 IDE_Morph.prototype.userMenu = function () {
     var menu = new MenuMorph(this);
-    menu.addItem('help', 'nop');
+    // menu.addItem('help', 'nop');
     return menu;
 };
 

--- a/objects.js
+++ b/objects.js
@@ -2577,7 +2577,7 @@ SpriteMorph.prototype.userMenu = function () {
         menu = new MenuMorph(this);
 
     if (ide && ide.isAppMode) {
-        menu.addItem('help', 'nop');
+        // menu.addItem('help', 'nop');
         return menu;
     }
     menu.addItem("duplicate", 'duplicate');
@@ -5116,7 +5116,7 @@ StageMorph.prototype.userMenu = function () {
         myself = this;
 
     if (ide && ide.isAppMode) {
-        menu.addItem('help', 'nop');
+        // menu.addItem('help', 'nop');
         return menu;
     }
     menu.addItem("edit", 'edit');


### PR DESCRIPTION
This does what the title says! It doesn't solve all the problems with help menus, just explicitly the ones which were labeled as 'nop'. 
The only other help menus I see are blocks, at least as far as I can tell. 

There is one minor issue. Right clicking on a morph which used to have a menu draws a box even when there are no items. (I should be able to fix this, if it matters. It's mildly bothersome to me, but the empty menu disappears when you click away, so it's not a big deal.)

![screen shot 2014-07-11 at 2 26 32 am](https://cloud.githubusercontent.com/assets/1505907/3550798/fadfe834-08dd-11e4-8cad-0f663dabd7d6.png)
