### PR TITLE
List.toString will show contents of the list

### DIFF
--- a/lists.js
+++ b/lists.js
@@ -112,7 +112,7 @@ function List(array) {
 }
 
 List.prototype.toString = function () {
-    return 'a List [' + this.asArray + ']';
+    return 'a List [' + this.asArray() + ']';
 };
 
 // List updating:


### PR DESCRIPTION
The allows the printing of a list as string to actually how the contents of a list.

-- to be honest, I'm not positive if this was the intended behavior or not. This is somewhat of an edge case to actually happen in Snap! 
