### PR TITLE
All block reporters to be clickable in dev mode

### DIFF
--- a/blocks.js
+++ b/blocks.js
@@ -1626,7 +1626,7 @@ SyntaxElementMorph.prototype.showBubble = function (value) {
         txt,
         img,
         morphToShow,
-        isClickable = false,
+        isClickable = false || this.world().isDevMode,
         wrrld = this.world();
 
     if ((value === undefined) || !wrrld) {


### PR DESCRIPTION
In dev mode you can now right click a speech bubble as a block is
reporting to inspect it using the developer menu.
