### PR TITLE
Add Portuguese translation of 'move'.

### DIFF
--- a/lang-pt.js
+++ b/lang-pt.js
@@ -835,6 +835,8 @@ SnapTranslator.dict.pt = {
     // actores:
     'edit':
         'editar',
+    'move':
+        'mover',
     'detach from':
         'soltar de',
     'detach all parts':


### PR DESCRIPTION
Move was added to the German translation.
