### PR TITLE
Don't allow sprites to be called mouse-pointer (fix #71)

### DIFF
--- a/objects.js
+++ b/objects.js
@@ -1398,8 +1398,11 @@ SpriteMorph.prototype.appearIn = function (ide) {
 // SpriteMorph versioning
 
 SpriteMorph.prototype.setName = function (string) {
-    this.name = string || this.name;
-    this.version = Date.now();
+    if (string != 'mouse-pointer' && string != 'pen trails'
+            && string != 'edge') { // used by system
+        this.name = string || this.name;
+        this.version = Date.now();
+    }
 };
 
 // SpriteMorph rendering


### PR DESCRIPTION
Invalid names are: `mouse-pointer, edge, pen trails`.
