### PR TITLE
Make '(temporary)' watcher string localizable

### DIFF
--- a/threads.js
+++ b/threads.js
@@ -1170,7 +1170,7 @@ Process.prototype.doShowVar = function (varName) {
             if (isGlobal || target.owner) {
                 label = name;
             } else {
-                label = name + ' (temporary)';
+                label = name + ' (' + localize('temporary') + ')';
             }
             watcher = new WatcherMorph(
                 label,


### PR DESCRIPTION
Mentioned in https://github.com/jmoenig/Snap--Build-Your-Own-Blocks/issues/429, point 5)
