### PR TITLE
don't allow the context menu to show up for a BlockMorph inside a WatcherMorph (fix #378)

### DIFF
--- a/blocks.js
+++ b/blocks.js
@@ -2048,6 +2048,7 @@ BlockMorph.prototype.userMenu = function () {
         top,
         blck;
 
+    if (this.parent.parent instanceof WatcherMorph) {return; }
     menu.addItem(
         "help...",
         'showHelp'


### PR DESCRIPTION
This prevents ringyfying a true/false block in a variable watcher.
