### PR TITLE
Fixed percent symbols in custom blocks

### DIFF
--- a/byob.js
+++ b/byob.js
@@ -688,7 +688,8 @@ CustomCommandBlockMorph.prototype.labelPart = function (spec) {
         return CustomCommandBlockMorph.uber.labelPart.call(this, spec);
     }
     if ((spec[0] === '%') && (spec.length > 1)) {
-        part = new BlockInputFragmentMorph(spec.slice(1));
+        var label = spec.replace(/%/g, '');
+        part = new BlockInputFragmentMorph(label);
     } else {
         part = new BlockLabelFragmentMorph(spec);
         part.fontSize = this.fontSize;


### PR DESCRIPTION
This fixes issue #476. Custom blocks can now handle multiple percent symbols in the input text when creating the block and multiple percent symbols in the custom block editor when a text with one or more leading percent symbols is selected to be an input name. All other original functionality is preserved: when percent symbols are used in the initial creation of a block, the input name does not include the leading percent symbols, and when percent symbols are used in the block editor when changing the label, percent symbols are included in the input name. Please let me know if this behavior should be different. 
