### PR TITLE
Set Default Save location to Cloud on Snap! load

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -190,7 +190,7 @@ IDE_Morph.prototype.init = function (isAutoFill) {
 
     // additional properties:
     this.cloudMsg = null;
-    this.source = 'local';
+    this.source = SnapCloud.username ? 'cloud' : 'local';
     this.serializer = new SnapSerializer();
 
     this.globalVariables = new VariableFrame();


### PR DESCRIPTION
When Snap! is loaded, Snap! will now check whether a user is logged in
(via the presence of `SnapCloud.username`) and if so, the default save
location will be the cloud.

_NOTE:_ currently, I'm not able to really test this since I'm never logged
in during local development...however, I do know the code doesn't error, so
that's good. ;-)
