### PR TITLE
Unregistered keyboard shortcuts go to browser

### DIFF
--- a/morphic.js
+++ b/morphic.js
@@ -4496,6 +4496,9 @@ CursorMorph.prototype.processKeyPress = function (event) {
     if (event.keyCode) { // Opera doesn't support charCode
         if (event.ctrlKey) {
             this.ctrl(event.keyCode, event.shiftKey);
+            if (event.keyCode !== 86) { // allow pasting-in
+                event.preventDefault();
+            }
         } else if (event.metaKey) {
             this.cmd(event.keyCode, event.shiftKey);
         } else {
@@ -4507,6 +4510,9 @@ CursorMorph.prototype.processKeyPress = function (event) {
     } else if (event.charCode) { // all other browsers
         if (event.ctrlKey) {
             this.ctrl(event.charCode, event.shiftKey);
+            if (event.charCode !== 86) { // allow pasting-in
+                event.preventDefault();
+            }
         } else if (event.metaKey) {
             this.cmd(event.charCode, event.shiftKey);
         } else {
@@ -4526,6 +4532,9 @@ CursorMorph.prototype.processKeyDown = function (event) {
     this.keyDownEventUsed = false;
     if (event.ctrlKey) {
         this.ctrl(event.keyCode, event.shiftKey);
+        if (event.keyCode !== 86) { // allow pasting-in
+            event.preventDefault();
+        }
         // notify target's parent of key event
         this.target.escalateEvent('reactToKeystroke', event);
         return;
@@ -10319,10 +10328,6 @@ WorldMorph.prototype.initEventListeners = function () {
                 if (myself.keyboardReceiver) {
                     myself.keyboardReceiver.processKeyPress(event);
                 }
-                event.preventDefault();
-            }
-            if ((event.ctrlKey || event.metaKey) &&
-                    (event.keyIdentifier !== 'U+0056')) { // allow pasting-in
                 event.preventDefault();
             }
         },

--- a/objects.js
+++ b/objects.js
@@ -4696,25 +4696,31 @@ StageMorph.prototype.fireKeyEvent = function (key) {
 
     this.keysPressed[evt] = true;
     if (evt === 'ctrl enter') {
+        event.preventDefault();
         return this.fireGreenFlagEvent();
     }
     if (evt === 'ctrl f') {
+        event.preventDefault();
         if (!ide.isAppMode) {ide.currentSprite.searchBlocks(); }
         return;
     }
     if (evt === 'ctrl n') {
+        event.preventDefault();
         if (!ide.isAppMode) {ide.createNewProject(); }
         return;
     }
     if (evt === 'ctrl o') {
+        event.preventDefault();
         if (!ide.isAppMode) {ide.openProjectsBrowser(); }
         return;
     }
     if (evt === 'ctrl s') {
+        event.preventDefault();
         if (!ide.isAppMode) {ide.save(); }
         return;
     }
     if (evt === 'ctrl shift s') {
+        event.preventDefault();
         if (!ide.isAppMode) {return ide.saveProjectsBrowser(); }
         return;
     }


### PR DESCRIPTION
Keyboard shortcuts events not registered specifically for Snap, such as ctrl+shift+j to open javascript console in chrome, now go to default browser events.
