### PR TITLE
Added targeted message sending and rebuilt broadcast functions to use them (DRY principle)

### DIFF
--- a/objects.js
+++ b/objects.js
@@ -601,6 +601,16 @@ SpriteMorph.prototype.initBlocks = function () {
             category: 'control',
             spec: 'broadcast %msg and wait'
         },
+        doMessageTo: {
+            type: 'command',
+            category: 'control',
+            spec: 'message %msg to %col'
+        },
+        doMessageToAndWait: {
+            type: 'command',
+            category: 'control',
+            spec: 'message %msg to %col and wait'
+        },
         getLastMessage: {
             type: 'reporter',
             category: 'control',
@@ -1255,8 +1265,10 @@ SpriteMorph.prototype.blockAlternatives = {
     // control:
     receiveGo: ['receiveClick'],
     receiveClick: ['receiveGo'],
-    doBroadcast: ['doBroadcastAndWait'],
-    doBroadcastAndWait: ['doBroadcast'],
+    doBroadcast: ['doBroadcastAndWait', 'doMessageTo', 'doMessageToAndWait'],
+    doBroadcastAndWait: ['doBroadcast', 'doMessageTo', 'doMessageToAndWait'],
+    doMessageTo: ['doMessageToAndWait', 'doBroadcast', 'doBroadcastAndWait'],
+    doMessageToAndWait: ['doMessageTo', 'doBroadcast', 'doBroadcastAndWait'],
     doIf: ['doIfElse', 'doUntil'],
     doIfElse: ['doIf', 'doUntil'],
     doRepeat: ['doUntil'],
@@ -1833,6 +1845,8 @@ SpriteMorph.prototype.blockTemplates = function (category) {
         blocks.push('-');
         blocks.push(block('doBroadcast'));
         blocks.push(block('doBroadcastAndWait'));
+        blocks.push(block('doMessageTo'));
+        blocks.push(block('doMessageToAndWait'));
         blocks.push(watcherToggle('getLastMessage'));
         blocks.push(block('getLastMessage'));
         blocks.push('-');
@@ -4994,6 +5008,8 @@ StageMorph.prototype.blockTemplates = function (category) {
         blocks.push('-');
         blocks.push(block('doBroadcast'));
         blocks.push(block('doBroadcastAndWait'));
+        blocks.push(block('doMessageTo'));
+        blocks.push(block('doMessageToAndWait'));
         blocks.push(watcherToggle('getLastMessage'));
         blocks.push(block('getLastMessage'));
         blocks.push('-');

--- a/threads.js
+++ b/threads.js
@@ -1864,13 +1864,23 @@ Process.prototype.reportURL = function (url) {
 // Process event messages primitives
 
 Process.prototype.doBroadcast = function (message) {
+    return this.doMessageTo(message, '');
+}
+
+Process.prototype.doBroadcastAndWait = function (message) {
+    return this.doMessageToAndWait(message, '');
+}
+
+Process.prototype.doMessageTo = function (message, morphName) {
     var stage = this.homeContext.receiver.parentThatIsA(StageMorph),
         hats = [],
         procs = [];
-
+        morphs = [];
     if (message !== '') {
         stage.lastMessage = message;
-        stage.children.concat(stage).forEach(function (morph) {
+        morphs = morphName != '' ? this.getObjectsNamed(morphName, this, stage) :
+                                    stage.children.concat(stage);
+        morphs.forEach(function (morph) {
             if (morph instanceof SpriteMorph || morph instanceof StageMorph) {
                 hats = hats.concat(morph.allHatBlocksFor(message));
             }
@@ -1880,11 +1890,11 @@ Process.prototype.doBroadcast = function (message) {
         });
     }
     return procs;
-};
+}
 
-Process.prototype.doBroadcastAndWait = function (message) {
+Process.prototype.doMessageToAndWait = function (message, morphName) {
     if (!this.context.activeSends) {
-        this.context.activeSends = this.doBroadcast(message);
+        this.context.activeSends = this.doMessageTo(message, morphName);
     }
     this.context.activeSends = this.context.activeSends.filter(
         function (proc) {
@@ -1896,7 +1906,7 @@ Process.prototype.doBroadcastAndWait = function (message) {
     }
     this.pushContext('doYield');
     this.pushContext();
-};
+}
 
 Process.prototype.getLastMessage = function () {
     var stage;


### PR DESCRIPTION
Dear Jens,

I have been working with Snap! for a college course I'm taking and for the final course project I'm working on (adding rigid body to SpriteMorphs) I could take advantage of having the possibility to target sprites when sending messages so I added this to my working branch. For me this makes Snap! a lot more OOP.

Obviously I must assume that if you didn't add this yourself it's because you don't see the need for it, nevertheless I thought I ought to share this with you.

Thank you for the great project that is Snap!
