### PR TITLE
New Keyboard Shortcuts for Snap!

### DIFF
--- a/objects.js
+++ b/objects.js
@@ -4735,59 +4735,68 @@ StageMorph.prototype.fireKeyEvent = function (key) {
         return this.fireGreenFlagEvent();
     }
     if (evt === 'ctrl f') {
-        return this.parentThatIsA(IDE_Morph).currentSprite.searchBlocks();
+        if (!ide.isAppMode) {ide.currentSprite.searchBlocks(); }
+        return;
     }
     if (evt === 'ctrl n') {
-        return this.parentThatIsA(IDE_Morph).createNewProject();
+        if (!ide.isAppMode) {ide.createNewProject(); }
+        return;
     }
     if (evt === 'ctrl o') {
-        return this.parentThatIsA(IDE_Morph).openProjectsBrowser();
+        if (!ide.isAppMode) {ide.openProjectsBrowser(); }
+        return;
     }
     if (evt === 'ctrl s') {
-        return this.parentThatIsA(IDE_Morph).save();
+        if (!ide.isAppMode) {ide.save(); }
+        return;
     }
     if (evt === 'ctrl shift s') {
-        return this.parentThatIsA(IDE_Morph).saveProjectsBrowser();
+        if (!ide.isAppMode) {return ide.saveProjectsBrowser(); }
+        return;
     }
     if (evt === 'ctrl esc') {
         return this.fireStopAllEvent();
     }
     if (evt === 'ctrl q') { 
-        return myself.parentThatIsA(IDE_Morph).spriteEditor.contents
-        .addComment();
+        if (!ide.isAppMode) {return ide.spriteEditor.contents.addComment(); }
+        return;
         
     }
     if (evt === 'ctrl y') { 
-        return myself.parentThatIsA(IDE_Morph).spriteEditor.contents
-            .cleanUp();
+        if (!ide.isAppMode) {return ide.spriteEditor.contents.cleanUp(); }
+        return;
     }
     if (evt === 'ctrl u') { 
-        return myself.parentThatIsA(IDE_Morph).spriteEditor.contents
-            .undrop();
+        if (!ide.isAppMode) {return ide.spriteEditor.contents.undrop(); }
+        return;
     }
     if (evt === 'ctrl d') {
-        myself.parentThatIsA(IDE_Morph).spriteEditor.contents
-            .lastDroppedBlock.destroy();
-        myself.parentThatIsA(IDE_Morph).spriteEditor.contents
-            .lastDroppedBlock = null;
+        if (!ide.isAppMode) {
+            ide.spriteEditor.contents.lastDroppedBlock.destroy();
+            ide.spriteEditor.contents.lastDroppedBlock = null;
+        }
+        return;
     }
     if (evt === 'ctrl r') {
-        myself.parentThatIsA(IDE_Morph).spriteEditor.contents
-            .lastDroppedBlock.ringify();
+        if (!ide.isAppMode) {
+            ide.spriteEditor.contents.lastDroppedBlock.ringify(); 
+        }
+        return;
     }
     if (evt === 'ctrl e') {
         var block = myself.parentThatIsA(IDE_Morph).spriteEditor.contents
             .lastDroppedBlock;
-        if (block.parentThatIsA(RingMorph)) {
+        if (block.parentThatIsA(RingMorph) && (!ide.isAppMode)) {
             block.unringify();
         }
+        return;
     }
     if (evt === 'esc') {
-        myself.parentThatIsA(IDE_Morph).controlBar.appModeButton.trigger();
+        if (ide.isAppMode) {ide.controlBar.appModeButton.trigger(); }
+        return;
     }
     if (evt === 'ctrl c') { 
-        var toCopy = myself.parentThatIsA(IDE_Morph).spriteEditor.contents
-            .lastDroppedBlock; 
+        var toCopy = ide.spriteEditor.contents.lastDroppedBlock; 
         var copy = function (input) {
             var dup = input.fullCopy(),
                 ide = input.parentThatIsA(IDE_Morph);
@@ -4799,13 +4808,13 @@ StageMorph.prototype.fireKeyEvent = function (key) {
                 };
             }
         }
-        copy(toCopy);
+        return copy(toCopy);
     }
 
     if (evt === 'ctrl l') {
         var libraries = function () {
             // read a list of libraries from an external file,
-            var world = myself.parentThatIsA(IDE_Morph).world();
+            var world = ide.world();
             var pos = myself.parentThatIsA(IDE_Morph).controlBar
                 .projectButton.bottomLeft();
             var libMenu = new MenuMorph(this, 'Import library'),

--- a/objects.js
+++ b/objects.js
@@ -4735,28 +4735,145 @@ StageMorph.prototype.fireKeyEvent = function (key) {
         return this.fireGreenFlagEvent();
     }
     if (evt === 'ctrl f') {
-        if (!ide.isAppMode) {ide.currentSprite.searchBlocks(); }
-        return;
+        return this.parentThatIsA(IDE_Morph).currentSprite.searchBlocks();
     }
     if (evt === 'ctrl n') {
-        if (!ide.isAppMode) {ide.createNewProject(); }
-        return;
+        return this.parentThatIsA(IDE_Morph).createNewProject();
     }
     if (evt === 'ctrl o') {
-        if (!ide.isAppMode) {ide.openProjectsBrowser(); }
-        return;
+        return this.parentThatIsA(IDE_Morph).openProjectsBrowser();
     }
     if (evt === 'ctrl s') {
-        if (!ide.isAppMode) {ide.save(); }
-        return;
+        return this.parentThatIsA(IDE_Morph).save();
     }
     if (evt === 'ctrl shift s') {
-        if (!ide.isAppMode) {return ide.saveProjectsBrowser(); }
-        return;
+        return this.parentThatIsA(IDE_Morph).saveProjectsBrowser();
     }
-    if (evt === 'esc') {
+    if (evt === 'ctrl esc') {
         return this.fireStopAllEvent();
     }
+    if (evt === 'ctrl q') { 
+        return myself.parentThatIsA(IDE_Morph).spriteEditor.contents
+        .addComment();
+        
+    }
+    if (evt === 'ctrl y') { 
+        return myself.parentThatIsA(IDE_Morph).spriteEditor.contents
+            .cleanUp();
+    }
+    if (evt === 'ctrl u') { 
+        return myself.parentThatIsA(IDE_Morph).spriteEditor.contents
+            .undrop();
+    }
+    if (evt === 'ctrl d') {
+        myself.parentThatIsA(IDE_Morph).spriteEditor.contents
+            .lastDroppedBlock.destroy();
+        myself.parentThatIsA(IDE_Morph).spriteEditor.contents
+            .lastDroppedBlock = null;
+    }
+    if (evt === 'ctrl r') {
+        myself.parentThatIsA(IDE_Morph).spriteEditor.contents
+            .lastDroppedBlock.ringify();
+    }
+    if (evt === 'ctrl e') {
+        var block = myself.parentThatIsA(IDE_Morph).spriteEditor.contents
+            .lastDroppedBlock;
+        if (block.parentThatIsA(RingMorph)) {
+            block.unringify();
+        }
+    }
+    if (evt === 'esc') {
+        myself.parentThatIsA(IDE_Morph).controlBar.appModeButton.trigger();
+    }
+    if (evt === 'ctrl c') { 
+        var toCopy = myself.parentThatIsA(IDE_Morph).spriteEditor.contents
+            .lastDroppedBlock; 
+        var copy = function (input) {
+            var dup = input.fullCopy(),
+                ide = input.parentThatIsA(IDE_Morph);
+            dup.pickUp(world);
+            if (ide) {
+                    world.hand.grabOrigin = {
+                    origin: ide.palette,
+                    position: ide.palette.center()
+                };
+            }
+        }
+        copy(toCopy);
+    }
+
+    if (evt === 'ctrl l') {
+        var libraries = function () {
+            // read a list of libraries from an external file,
+            var world = myself.parentThatIsA(IDE_Morph).world();
+            var pos = myself.parentThatIsA(IDE_Morph).controlBar
+                .projectButton.bottomLeft();
+            var libMenu = new MenuMorph(this, 'Import library'),
+                libUrl = 'http://snap.berkeley.edu/snapsource/libraries/' +
+                    'LIBRARIES';
+
+            function loadLib(name) {
+                var url = 'http://snap.berkeley.edu/snapsource/libraries/'
+                        + name
+                        + '.xml';
+                myself.parentThatIsA(IDE_Morph).droppedText(myself.getURL(url), name);
+            }
+
+            myself.parentThatIsA(IDE_Morph).getURL(libUrl).split('\n')
+                .forEach(function (line) {
+                if (line.length > 0) {
+                    libMenu.addItem(
+                        line.substring(line.indexOf('\t') + 1),
+                        function () {
+                            loadLib(
+                                line.substring(0, line.indexOf('\t'))
+                            );
+                        }
+                    );
+                }
+            });
+        libMenu.popup(world, pos);
+        }
+        return libraries();
+    }
+    if (evt === 'ctrl i') {
+        var import_tools = function () {
+            myself.parentThatIsA(IDE_Morph).droppedText(
+                myself.parentThatIsA(IDE_Morph).getURLsbeOrRelative(
+                    'tools.xml'
+                ),
+                'tools'
+            );
+        };
+        return import_tools();
+    }
+
+    if (evt === 'ctrl b') {
+        var new_block = function () {
+            new BlockDialogMorph(
+                null,
+                function (definition) {
+                    if (definition.spec !== '') {
+                        if (definition.isGlobal) {
+                            myself.globalBlocks.push(definition);
+                        } else {
+                            myself.customBlocks.push(definition);
+                        }
+                        myself.parentThatIsA(IDE_Morph).flushPaletteCache();
+                        myself.parentThatIsA(IDE_Morph).refreshPalette();
+                        new BlockEditorMorph(definition, myself).popUp();
+                    }
+                },
+                myself
+            ).prompt(
+                'Make a block',
+                null,
+                myself.world()
+            );
+        }
+        return new_block();
+    }
+
     this.children.concat(this).forEach(function (morph) {
         if (morph instanceof SpriteMorph || morph instanceof StageMorph) {
             hats = hats.concat(morph.allHatBlocksForKey(evt));

--- a/objects.js
+++ b/objects.js
@@ -4796,19 +4796,23 @@ StageMorph.prototype.fireKeyEvent = function (key) {
         return;
     }
     if (evt === 'ctrl c') { 
-        var toCopy = ide.spriteEditor.contents.lastDroppedBlock; 
-        var copy = function (input) {
-            var dup = input.fullCopy(),
-                ide = input.parentThatIsA(IDE_Morph);
-            dup.pickUp(world);
-            if (ide) {
-                    world.hand.grabOrigin = {
-                    origin: ide.palette,
-                    position: ide.palette.center()
-                };
+        if (!ide.isAppMode) {
+            var toCopy = ide.spriteEditor.contents.lastDroppedBlock; 
+            var copy = function (input) {
+                var dup = input.fullCopy(),
+                    ide = input.parentThatIsA(IDE_Morph);
+                dup.pickUp(world);
+                if (ide) {
+                        world.hand.grabOrigin = {
+                        origin: ide.palette,
+                        position: ide.palette.center()
+                    };
+                }
             }
+            return copy(toCopy);
+        } else {
+            return;
         }
-        return copy(toCopy);
     }
 
     if (evt === 'ctrl l') {
@@ -4843,7 +4847,8 @@ StageMorph.prototype.fireKeyEvent = function (key) {
             });
         libMenu.popup(world, pos);
         }
-        return libraries();
+        if (!ide.isAppMode) {return libraries(); }
+        return;
     }
     if (evt === 'ctrl i') {
         var import_tools = function () {
@@ -4854,7 +4859,8 @@ StageMorph.prototype.fireKeyEvent = function (key) {
                 'tools'
             );
         };
-        return import_tools();
+        if (!ide.isAppMode) {return import_tools(); }
+        return;
     }
 
     if (evt === 'ctrl b') {
@@ -4880,7 +4886,8 @@ StageMorph.prototype.fireKeyEvent = function (key) {
                 myself.world()
             );
         }
-        return new_block();
+        if (!ide.isAppMode) {return new_block(); }
+        return;
     }
 
     this.children.concat(this).forEach(function (morph) {


### PR DESCRIPTION
Hi, my name is Christopher Kilian and I took the Snap Decal last semester. As my final project, I made some new keyboard shortcuts that I think would be useful for Snap. I forked the repository this morning so everything should be up to date. The only changes I made were in the objects.js file between lines 4734 and 4891. I tried to emulate the style the code was written in so the code would be readable and familiar. Here are the changed I made:
- ctrl q: Make a new comment
- ctrl y: Perform the "clean up" function that lines all the blocks up in a neat row.
- ctrl u: Undrop the last block you dropped. If you drop a large chunk of connected or nested blocks, it  undrops the entire chunk.
- ctrl d: Deleted the last block you placed.
- ctrl r: Ringifies the last block you placed
- ctrl e: Unringifies the last block you placed, but only if it is ringified.
- ctrl c: Copies the last block you placed. If you placed a chunk of connected or nested blocks, it copies the entire chunk.
- ctrl l: opens up the libraries menu
- ctrl i: imports tools
- ctrl b: create a new block
- esc: Exit presentation mode. Only works if you are already in presentation mode. One of the student instructors of the decal asked me to add this in. Note: the keyboard shortcut that already existed that stopped all scripts was already bound to escape, so I changed that one to ctrl esc.

I also made sure to add in the checks to make sure that these shortcuts only work when not in presentation mode (except for esc, which only works in presentation mode). Feel free to rebind the keys in any way you see fit. If you have any questions don't hesitate to ask.

Thank you!
