### PR TITLE
Fixed touch up event (e.g. in iPad) so that right mouse click simulation do not mess it.

### DIFF
--- a/morphic.js
+++ b/morphic.js
@@ -6909,16 +6909,18 @@ MenuMorph.prototype.popup = function (world, pos) {
         world.activeMenu.destroy();
     }
     if (this.items.length < 1 && !this.title) { // don't show empty menus
-        return;
+        return false;
     }
     world.add(this);
     world.activeMenu = this;
     this.fullChanged();
+	  return true;
 };
 
 MenuMorph.prototype.popUpAtHand = function (world) {
     var wrrld = world || this.world;
-    this.popup(wrrld, wrrld.hand.position());
+    var menuOpened = this.popup(wrrld, wrrld.hand.position());
+	return menuOpened;
 };
 
 MenuMorph.prototype.popUpCenteredAtHand = function (world) {
@@ -9563,8 +9565,14 @@ HandMorph.prototype.processTouchStart = function (event) {
     if (event.touches.length === 1) {
         this.touchHoldTimeout = setInterval( // simulate mouseRightClick
             function () {
+				// if the context menu is not opened after mouseRightClick, restore original mouse button
+				var currentMouseButton = myself.mouseButton;
                 myself.processMouseDown({button: 2});
-                myself.processMouseUp({button: 2});
+                var isContextMenuOpened = myself.processMouseUp({button: 2});
+				if (!isContextMenuOpened) {
+					myself.mouseButton = currentMouseButton;
+				}
+				
                 event.preventDefault();
                 clearInterval(myself.touchHoldTimeout);
             },
@@ -9597,6 +9605,7 @@ HandMorph.prototype.processMouseUp = function () {
         context,
         contextMenu,
         expectedClick;
+	  var	isContextMenuOpened = false;
 
     this.destroyTemporaries();
     if (this.children.length !== 0) {
@@ -9615,8 +9624,8 @@ HandMorph.prototype.processMouseUp = function () {
                     contextMenu = context.contextMenu();
                 }
                 if (contextMenu) {
-                    contextMenu.popUpAtHand(this.world);
-                }
+                    isContextMenuOpened = contextMenu.popUpAtHand(this.world);
+               }
             }
         }
         while (!morph[expectedClick]) {
@@ -9625,6 +9634,7 @@ HandMorph.prototype.processMouseUp = function () {
         morph[expectedClick](this.bounds.origin);
     }
     this.mouseButton = null;
+	  return isContextMenuOpened;
 };
 
 HandMorph.prototype.processDoubleClick = function () {


### PR DESCRIPTION
Symptoms:
In iPad, the touch up event (i.e. "mouseClickLeft" ) do not come if the finger do not move. That is because after 400 ms the touch is interpreted as a long press and the right mouse click simulation begins. The simulation overwrites the original left mouse button state. Because of this defect it is not possible to make game with touch controls for iPad.

The Fix:
- store the current mouse button value before simulating the right mouse click
- return the information on whether the context menu was really opened after the right mouse click
- if the context menu was not opened, restore the original mouse button value
- Note: the fix really affects only to touch functionality. The Mouse functionality should be as it was. 

Note:
I am a very experienced C++ coder but my Javascript knowledge was practically zero. Hopefully, the code is not too C++ like :-)
