### PR TITLE
Split "Variables" category

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -931,9 +931,7 @@ IDE_Morph.prototype.createCategories = function () {
     }
 
     SpriteMorph.prototype.categories.forEach(function (cat) {
-        if (!contains(['lists', 'other'], cat)) {
-            addCategoryButton(cat);
-        }
+        addCategoryButton(cat);
     });
     fixCategoriesLayout();
     this.add(this.categories);

--- a/objects.js
+++ b/objects.js
@@ -2095,7 +2095,7 @@ SpriteMorph.prototype.blockTemplates = function (category) {
             blocks.push(block('doDeleteAttr'));
         }
 
-    ///////////////////////////////
+    } else if (cat === 'lists') {
 
         blocks.push('=');
 
@@ -2129,9 +2129,7 @@ SpriteMorph.prototype.blockTemplates = function (category) {
             blocks.push(block('doForEach'));
         }
 
-    /////////////////////////////////
-
-        blocks.push('=');
+    } else if (cat === 'other') {
 
         if (StageMorph.prototype.enableCodeMapping) {
             blocks.push(block('doMapCodeOrHeader'));
@@ -2341,11 +2339,7 @@ SpriteMorph.prototype.freshPalette = function (category) {
         stage.globalBlocks.forEach(function (definition) {
             var block;
             if (definition.category === category ||
-                    (category === 'variables'
-                        && contains(
-                            ['lists', 'other'],
-                            definition.category
-                        ))) {
+                    category === 'other') {
                 block = definition.templateInstance();
                 y += unit * 0.3;
                 block.setPosition(new Point(x, y));
@@ -2362,11 +2356,7 @@ SpriteMorph.prototype.freshPalette = function (category) {
     this.customBlocks.forEach(function (definition) {
         var block;
         if (definition.category === category ||
-                (category === 'variables'
-                    && contains(
-                        ['lists', 'other'],
-                        definition.category
-                    ))) {
+                category === 'other') {
             block = definition.templateInstance();
             y += unit * 0.3;
             block.setPosition(new Point(x, y));
@@ -5614,6 +5604,9 @@ StageMorph.prototype.blockTemplates = function (category) {
         blocks.push(block('doHideVar'));
         blocks.push(block('doDeclareVariables'));
         blocks.push('=');
+
+    } else if (cat === 'lists') {
+
         blocks.push(block('reportNewList'));
         blocks.push('-');
         blocks.push(block('reportCONS'));
@@ -5644,9 +5637,7 @@ StageMorph.prototype.blockTemplates = function (category) {
             blocks.push(block('doForEach'));
         }
 
-    /////////////////////////////////
-
-        blocks.push('=');
+    } else if (cat === 'other') {
 
         if (StageMorph.prototype.enableCodeMapping) {
             blocks.push(block('doMapCodeOrHeader'));

--- a/objects.js
+++ b/objects.js
@@ -2097,8 +2097,6 @@ SpriteMorph.prototype.blockTemplates = function (category) {
 
     } else if (cat === 'lists') {
 
-        blocks.push('=');
-
         blocks.push(block('reportNewList'));
         blocks.push('-');
         blocks.push(block('reportCONS'));


### PR DESCRIPTION
This splits the "Variables" category in the palette into three new ones: Variables, Lists, and Other.

<img width="205" alt="screenshot 2015-08-14 12 03 50" src="https://cloud.githubusercontent.com/assets/639289/9272648/8ec35666-427c-11e5-9e7e-cbc7e88701be.png">

The Other category shows every custom block, even those which appear under separate categories. When we clone ScratchX's JS extension support, we can also include extension blocks under the "other" category.

The "other" category should probably be renamed "More Blocks" or "Custom Blocks". That can be a separate PR.
