### PR TITLE
Fix input sliders

### DIFF
--- a/morphic.js
+++ b/morphic.js
@@ -5749,9 +5749,9 @@ SliderMorph.uber = CircleBoxMorph.prototype;
 
 function SliderMorph(start, stop, value, size, orientation, color) {
     this.init(
-        start || 1,
-        stop || 100,
-        value || 50,
+        typeof start === 'number' ? start : 1,
+        typeof stop === 'number' ? stop : 100,
+        typeof value === 'number' ? value : 50,
         size || 10,
         orientation || 'vertical',
         color


### PR DESCRIPTION
This prevents input sliders from behaving strangely when the input’s
value is -25, 0, or 25.

Usually they look like this:
![screen shot 2015-09-26 at 6 15 47 pm](https://cloud.githubusercontent.com/assets/5834370/10120133/fad87eb0-647a-11e5-89af-4f84c07394c2.png)
But at certain values the range gets messed up:
![screen shot 2015-09-26 at 6 16 13 pm](https://cloud.githubusercontent.com/assets/5834370/10120134/08cbe444-647b-11e5-9722-7dec71e8ea42.png)
![screen shot 2015-09-26 at 6 16 41 pm](https://cloud.githubusercontent.com/assets/5834370/10120135/0c11e978-647b-11e5-9d14-c7b4c41c1e34.png)
![screen shot 2015-09-26 at 6 17 09 pm](https://cloud.githubusercontent.com/assets/5834370/10120136/0dd8196c-647b-11e5-9f73-52b3a3b0ec53.png) (this one's only 1 smaller than usual)
