### PR TITLE
Added protection from performing illegal mathematical operations

### DIFF
--- a/objects.js
+++ b/objects.js
@@ -3445,7 +3445,12 @@ SpriteMorph.prototype.setPosition = function (aPoint, justMe) {
 
 SpriteMorph.prototype.forward = function (steps) {
     var dest,
-        dist = steps * this.parent.scale || 0;
+        dist;
+    
+    if (isNaN(steps) || !isFinite(steps)) {
+        steps = 0;
+    }
+    dist = steps * this.parent.scale || 0;
 
     if (dist >= 0) {
         dest = this.position().distanceAngle(dist, this.heading);
@@ -3463,7 +3468,13 @@ SpriteMorph.prototype.setHeading = function (degrees) {
     var x = this.xPosition(),
         y = this.yPosition(),
         dir = (+degrees || 0),
-        turn = dir - this.heading;
+        turn;
+        
+    if (isNaN(dir) || !isFinite(dir)) {
+        dir = 0;
+    }
+    
+    turn = dir - this.heading;
 
     // apply to myself
     this.changed();
@@ -3538,6 +3549,13 @@ SpriteMorph.prototype.gotoXY = function (x, y, justMe) {
         newX,
         newY,
         dest;
+        
+    if (isNaN(x) || !isFinite(x)) {
+        x = 0;
+    }
+    if (isNaN(y) || !isFinite(y)) {
+        y = 0;
+    }
 
     if (!stage) {return; }
     newX = stage.center().x + (+x || 0) * stage.scale;

--- a/objects.js
+++ b/objects.js
@@ -141,15 +141,6 @@ var StagePrompterMorph;
 var Note;
 var SpriteHighlightMorph;
 
-function defaultFiniteValue(num, def) {
-	num = +num || 0;
-    if (isNaN(num) || !isFinite(num)) {
-        return def;
-    } else {
-        return num;
-    }
-}
-
 // SpriteMorph /////////////////////////////////////////////////////////
 
 // I am a scriptable object
@@ -3452,11 +3443,20 @@ SpriteMorph.prototype.setPosition = function (aPoint, justMe) {
     }
 };
 
+SpriteMorph.prototype.defaultFiniteValue = function (num, def) {
+	num = +num || 0;
+    if (isNaN(num) || !isFinite(num)) {
+        return def;
+    } else {
+        return num;
+    }
+}
+
 SpriteMorph.prototype.forward = function (steps) {
     var dest,
         dist;
     
-    steps = defaultFiniteValue(steps, 0);
+    steps = this.defaultFiniteValue(steps, 0);
     dist = steps * this.parent.scale || 0;
 
     if (dist >= 0) {
@@ -3474,7 +3474,7 @@ SpriteMorph.prototype.forward = function (steps) {
 SpriteMorph.prototype.setHeading = function (degrees) {
     var x = this.xPosition(),
         y = this.yPosition(),
-        dir = defaultFiniteValue(degrees, 0),
+        dir = this.defaultFiniteValue(degrees, 0),
         turn = dir - this.heading;
 
     // apply to myself
@@ -3551,8 +3551,8 @@ SpriteMorph.prototype.gotoXY = function (x, y, justMe) {
         newY,
         dest;
     
-    x = defaultFiniteValue(x, 0);
-    y = defaultFiniteValue(y, 0); 
+    x = this.defaultFiniteValue(x, 0);
+    y = this.defaultFiniteValue(y, 0);
 
     if (!stage) {return; }
     newX = stage.center().x + (+x || 0) * stage.scale;

--- a/objects.js
+++ b/objects.js
@@ -141,6 +141,15 @@ var StagePrompterMorph;
 var Note;
 var SpriteHighlightMorph;
 
+function defaultFiniteValue(num, def) {
+	num = +num || 0;
+    if (isNaN(num) || !isFinite(num)) {
+        return def;
+    } else {
+        return num;
+    }
+}
+
 // SpriteMorph /////////////////////////////////////////////////////////
 
 // I am a scriptable object
@@ -3447,9 +3456,7 @@ SpriteMorph.prototype.forward = function (steps) {
     var dest,
         dist;
     
-    if (isNaN(steps) || !isFinite(steps)) {
-        steps = 0;
-    }
+    steps = defaultFiniteValue(steps, 0);
     dist = steps * this.parent.scale || 0;
 
     if (dist >= 0) {
@@ -3467,14 +3474,8 @@ SpriteMorph.prototype.forward = function (steps) {
 SpriteMorph.prototype.setHeading = function (degrees) {
     var x = this.xPosition(),
         y = this.yPosition(),
-        dir = (+degrees || 0),
-        turn;
-        
-    if (isNaN(dir) || !isFinite(dir)) {
-        dir = 0;
-    }
-    
-    turn = dir - this.heading;
+        dir = defaultFiniteValue(degrees, 0),
+        turn = dir - this.heading;
 
     // apply to myself
     this.changed();
@@ -3549,13 +3550,9 @@ SpriteMorph.prototype.gotoXY = function (x, y, justMe) {
         newX,
         newY,
         dest;
-        
-    if (isNaN(x) || !isFinite(x)) {
-        x = 0;
-    }
-    if (isNaN(y) || !isFinite(y)) {
-        y = 0;
-    }
+    
+    x = defaultFiniteValue(x, 0);
+    y = defaultFiniteValue(y, 0); 
 
     if (!stage) {return; }
     newX = stage.center().x + (+x || 0) * stage.scale;

--- a/threads.js
+++ b/threads.js
@@ -2036,14 +2036,32 @@ Process.prototype.reportProduct = function (a, b) {
     return +a * +b;
 };
 
+function QuotientNaNException(numerator, denominator) {
+    this.name = "Quotient exception";
+    this.message = "illegal division operation: (" + numerator + ") / (" + denominator + ")";
+}
+
 Process.prototype.reportQuotient = function (a, b) {
-    return +a / +b;
+    var result = +a / +b;
+    if (isNaN(result) || +b === 0) {
+        throw new QuotientNaNException(+a, +b);
+    }
+    return result;
 };
+
+function ModulusNaNException(numerator, denominator) {
+    this.name = "Modulus exception";
+    this.message = "illegal modulus operation: (" + numerator + ") / (" + denominator + ")";
+}
 
 Process.prototype.reportModulus = function (a, b) {
     var x = +a,
         y = +b;
-    return ((x % y) + y) % y;
+    var result = ((x % y) + y) % y;
+    if (isNaN(result)) {
+        throw new ModulusNaNException(+a, +b);
+    }
+    return result;
 };
 
 Process.prototype.reportRandom = function (min, max) {
@@ -2128,6 +2146,11 @@ Process.prototype.reportRound = function (n) {
     return Math.round(+n);
 };
 
+function MonadicNaNException(func, number) {
+    this.name = "\"" + func + "\" exception";
+    this.message = "illegal " + func + " operation: " + func + "(" + number + ")";
+}
+
 Process.prototype.reportMonadic = function (fname, n) {
     var x = +n,
         result = 0;
@@ -2177,6 +2200,9 @@ Process.prototype.reportMonadic = function (fname, n) {
         break;
     default:
         nop();
+    }
+    if (isNaN(result)) {
+        throw new MonadicNaNException(fname, n);
     }
     return result;
 };

--- a/threads.js
+++ b/threads.js
@@ -1629,10 +1629,19 @@ Process.prototype.doForever = function (body) {
     this.pushContext();
 };
 
+function DoRepeatError(value) {
+	this.name = "Repeat Error";
+	this.message = localize("The repeat loop was given an unsupported number of repetitions: ") + value;
+}
+
 Process.prototype.doRepeat = function (counter, body) {
     var block = this.context.expression,
         outer = this.context.outerContext, // for tail call elimination
         isCustomBlock = this.context.isCustomBlock;
+
+	if (isNaN(counter) || !isFinite(counter)) {
+		throw new DoRepeatError(counter);
+	}
 
     if (counter < 1) { // was '=== 0', which caused infinite loops on non-ints
         return null;

--- a/threads.js
+++ b/threads.js
@@ -1628,19 +1628,18 @@ Process.prototype.doForever = function (body) {
     }
     this.pushContext();
 };
-
-function DoRepeatError(value) {
-	this.name = "Repeat Error";
-	this.message = localize("The repeat loop was given an " + 
-                            "unsupported number of repetitions: ") + value;
-}
-
 Process.prototype.doRepeat = function (counter, body) {
     var block = this.context.expression,
         outer = this.context.outerContext, // for tail call elimination
         isCustomBlock = this.context.isCustomBlock;
 
 	if (isNaN(counter) || !isFinite(counter)) {
+		function DoRepeatError(value) {
+			this.name = "Repeat Error";
+			this.message = localize("The repeat loop was given an " +
+			                        "unsupported number of repetitions: ") + value;
+		}
+
 		throw new DoRepeatError(counter);
 	}
 
@@ -2034,7 +2033,7 @@ Process.prototype.reportTypeOf = function (thing) {
 
 // Process math primtives
 
-function UndefinedOperationError(opName, argA, symbol, argB) {
+Process.prototype.UndefinedOperationError = function (opName, argA, symbol, argB) {
     var localOp = localize(opName);
     this.name = localize("%s operation error").replace("%s", localOp);
     this.message = localize("undefined %s operation:").replace("%s", localOp);
@@ -2046,29 +2045,29 @@ function UndefinedOperationError(opName, argA, symbol, argB) {
     }
 }
 
-function checkBinaryOperationResult(result, opName, argA, symbol, argB) {
+Process.prototype.checkBinaryOperationResult = function(result, opName, argA, symbol, argB) {
     if (isNaN(result)) {
-        throw new UndefinedOperationError(opName, argA, symbol, argB);
+        throw new this.UndefinedOperationError(opName, argA, symbol, argB);
     }
     return result;
 }
 
 Process.prototype.reportSum = function (a, b) {
-    return checkBinaryOperationResult(+a + +b, "sum", +a, "+", +b);
+    return this.checkBinaryOperationResult(+a + +b, "sum", +a, "+", +b);
 };
 
 Process.prototype.reportDifference = function (a, b) {
-    return checkBinaryOperationResult(+a - +b, "difference", +a, "-", +b);
+    return this.checkBinaryOperationResult(+a - +b, "difference", +a, "-", +b);
 };
 
 Process.prototype.reportProduct = function (a, b) {
-    return checkBinaryOperationResult(+a * +b, "product", +a, "*", +b);
+    return this.checkBinaryOperationResult(+a * +b, "product", +a, "*", +b);
 };
 
 Process.prototype.reportQuotient = function (a, b) {
     var result = +a / +b;
     if (isNaN(result) || +b === 0) {
-        throw new UndefinedOperationError("division", +a, "/", +b);
+        throw new this.UndefinedOperationError("division", +a, "/", +b);
     }
     return result;
 };
@@ -2078,7 +2077,7 @@ Process.prototype.reportModulus = function (a, b) {
         y = +b,
         result = ((x % y) + y) % y;
     if (isNaN(result) || y === 0) {
-        throw new UndefinedOperationError("modulus", x, "mod", y);
+        throw new this.UndefinedOperationError("modulus", x, "mod", y);
     }
     return result;
 };
@@ -2216,7 +2215,7 @@ Process.prototype.reportMonadic = function (fname, n) {
         nop();
     }
     if (isNaN(result)) {
-        throw new UndefinedOperationError(fname, n);
+        throw new this.UndefinedOperationError(fname, n);
     }
     return result;
 };


### PR DESCRIPTION
These changes cause the division block to raise an exception when a division by 0 is attempted, rather than returning "NaN" or "Infinity" (this is very confusing for people new to programming). It also prevents the modulus operation block from performing modulus by 0, and causes the monadic operation block (sqrt, pow) from doing things like `sqrt(-1)`.

Finally, it prevents sprites from moving to Infinity or NaN locations.
