### PR TITLE
"Save and Share..." option in the file menu

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -3483,7 +3483,10 @@ IDE_Morph.prototype.saveAndShare = function () {
 
     function shareProject() {
         var dialog, frame, text, width,
-            publicURL;
+            publicURL,
+            directions = new StringMorph(
+                localize('Use ^C to copy the address to the clipboard.')
+            );
 
         publicURL = myself.publicProjectURL(
             SnapCloud.username,
@@ -3527,7 +3530,7 @@ IDE_Morph.prototype.saveAndShare = function () {
         text.setWidth(width - frame.padding * 2);
         text.setPosition(frame.topLeft().add(frame.padding));
         text.enableSelecting();
-        text.isEditable = true;
+        text.isEditable = true; // we can't select text that isn't editable.
 
         frame.fixLayout = nop;
         frame.edge = InputFieldMorph.prototype.edge;
@@ -3541,12 +3544,17 @@ IDE_Morph.prototype.saveAndShare = function () {
         text.drawNew();
         dialog.addBody(frame);
         frame.drawNew();
+        dialog.add(directions);
         dialog.addButton('ok', 'OK');
         dialog.fixLayout();
+        directions.setPosition(new Point(
+            frame.left(),
+            frame.bottom() + frame.padding
+        ));
         dialog.drawNew();
         dialog.popUp(world);
         dialog.setCenter(world.center());
-        text.edit();
+        text.selectAll();
     }
 
     if (!this.projectName) {

--- a/gui.js
+++ b/gui.js
@@ -3478,41 +3478,48 @@ IDE_Morph.prototype.saveProject = function (name) {
 // Save a project and show a URL
 IDE_Morph.prototype.saveAndShare = function() {
     var myself = this,
-	projectName = this.projectName;
+        projectName = this.projectName,
+        projectDialog;
 
-    if (projectName) {
-	this.showMessage('Saving project\nto the cloud...');
-	this.setProjectName(projectName);
+    function shareProject() {
+        myself.showMessage('sharing\nproject...');
+        SnapCloud.reconnect(
+            function () {
+                SnapCloud.callService(
+                    'publishProject',
+                    function () {
+                        myself.showMessage('shared.', 2);
+                    },
+                    myself.cloudError(),
+                    [
+                        projectName,
+                        myself.stage.thumbnail(
+                            SnapSerializer.prototype.thumbnailSize
+                        ).toDataURL('image/png')
+                    ]
+                );
+            },
+            myself.cloudError()
+        );
+        prompt(
+            'This project is now public at the following URL:',
+            myself.publicProjectURL(myself.username, projectName)
+        );
+    }
 
-	SnapCloud.saveProject(
-	    this,
-	    function () {
-		myself.showMessage('sharing\nproject...');
-		SnapCloud.reconnect(
-		    function () {
-			SnapCloud.callService(
-			    'publishProject',
-			    function () {
-				myself.showMessage('shared.', 2);
-			    },
-			    myself.cloudError(),
-			    [
-				projectName,
-				myself.stage.thumbnail(
-				    SnapSerializer.prototype.thumbnailSize
-				).toDataURL('image/png')
-			    ]
-			);
-		    },
-		    myself.cloudError()
-		);
-		prompt(
-		    'This project is now public at the following URL:',
-		    this.publicProjectURL(this.username, projectName)
-		);
-	    },
-	    this.cloudError()
-	)
+    if (!projectName) {
+        projectDialog = new ProjectDialogMorph(this, 'save');
+        // When a project it saved to the cloud, also share it.
+        projectDialog.saveCloudProject = function () {
+            myself.showMessage('Saving project\nto the cloud...');
+            SnapCloud.saveProject(myself, saveProject, myself.cloudError());
+            this.destroy();
+        };
+        projectDialog.popUp();
+    } else {
+        this.showMessage('Saving project\nto the cloud...');
+        this.setProjectName(projectName);
+        SnapCloud.saveProject(this, shareProject, this.cloudError());
     }
 }
 
@@ -5288,11 +5295,16 @@ IDE_Morph.prototype.publicProjectURL = function (username, projectName) {
     return url;
 }
 
+<<<<<<< HEAD
 // IDE_Morph HTTP data fetching
 IDE_Morph.prototype.getURL = function (url, callback) {
     // fetch the contents of a url and pass it into the specified callback.
     // If no callback is specified synchronously fetch and return it
     // Note: Synchronous fetching has been deprecated and should be switched
+=======
+// IDE_Morph synchronous HTTP data fetching
+IDE_Morph.prototype.getURL = function (url) {
+>>>>>>> Improve save and share to show the save dialog for new projects
     var request = new XMLHttpRequest(),
         async = callback instanceof Function,
         myself = this;

--- a/gui.js
+++ b/gui.js
@@ -2802,6 +2802,7 @@ IDE_Morph.prototype.projectMenu = function () {
     menu.addPair('Open...', 'openProjectsBrowser', '⌘O');
     menu.addPair('Save', "save", '⌘S');
     menu.addItem('Save As...', 'saveProjectsBrowser');
+    menu.addItem('Save and Share...', "saveAndShare");
     menu.addLine();
     menu.addItem(
         'Import...',
@@ -2959,8 +2960,10 @@ IDE_Morph.prototype.projectMenu = function () {
     menu.popup(world, pos);
 };
 
-IDE_Morph.prototype.resourceURL = function () {
-    // Take in variadic inputs that represent an a nested folder structure.
+// IDE_Morph utility methods of dynamic submenu lists
+
+IDE_Morph.prototype.resourceURL = function (folder, file) {
+    // Give a path a file in subfolders.
     // Method can be easily overridden if running in a custom location.
     // Default Snap! simply returns a path (relative to snap.html)
     var args = Array.prototype.slice.call(arguments, 0);

--- a/gui.js
+++ b/gui.js
@@ -3481,6 +3481,8 @@ IDE_Morph.prototype.saveAndShare = function() {
         projectDialog;
 
     function shareProject() {
+	var urlDialog, urlBox;
+
         myself.showMessage('sharing\nproject...');
         SnapCloud.reconnect(
             function () {
@@ -3491,7 +3493,7 @@ IDE_Morph.prototype.saveAndShare = function() {
                     },
                     myself.cloudError(),
                     [
-                        projectName,
+			myself.projectName,
                         myself.stage.thumbnail(
                             SnapSerializer.prototype.thumbnailSize
                         ).toDataURL('image/png')
@@ -3500,10 +3502,21 @@ IDE_Morph.prototype.saveAndShare = function() {
             },
             myself.cloudError()
         );
-        prompt(
-            'This project is now public at the following URL:',
-	    myself.publicProjectURL(SnapCloud.username, myself.projectName)
+
+        urlDialog = new DialogBoxMorph();
+        urlDialog.labelString = 'Copy the public address:';
+        urlDialog.createLabel();
+        urlBox = new InputFieldMorph(
+            myself.publicProjectURL(SnapCloud.username, myself.projectName)
         );
+        urlBox.setWidth(300);
+        urlDialog.addBody(urlBox);
+        urlBox.drawNew();
+        urlDialog.addButton('ok', 'OK');
+        urlDialog.fixLayout();
+        urlDialog.drawNew();
+        urlDialog.fixLayout();
+        urlDialog.popUp(world);
     }
 
     if (!this.projectName) {
@@ -3511,16 +3524,16 @@ IDE_Morph.prototype.saveAndShare = function() {
         // When a project it saved to the cloud, also share it.
         projectDialog.saveCloudProject = function () {
             myself.showMessage('Saving project\nto the cloud...');
-	    SnapCloud.saveProject(
-		myself,
-		shareProject,
-		myself.cloudError());
+            SnapCloud.saveProject(
+                myself,
+                shareProject,
+                myself.cloudError());
             this.destroy();
         };
         projectDialog.popUp();
     } else {
         this.showMessage('Saving project\nto the cloud...');
-	this.setProjectName(this.projectName);
+        this.setProjectName(this.projectName);
         SnapCloud.saveProject(this, shareProject, this.cloudError());
     }
 };
@@ -5288,25 +5301,18 @@ IDE_Morph.prototype.setCloudURL = function () {
 IDE_Morph.prototype.publicProjectURL = function (username, projectName) {
     // Return a new URL to a public Snap! project
     var url = new URL(window.location);
-
     url.hash = 'present:' + SnapCloud.encodeDict({
         'Username': username,
         'ProjectName': projectName
     });
-
-    return url;
+    return url.href;
 }
 
-<<<<<<< HEAD
 // IDE_Morph HTTP data fetching
 IDE_Morph.prototype.getURL = function (url, callback) {
     // fetch the contents of a url and pass it into the specified callback.
     // If no callback is specified synchronously fetch and return it
     // Note: Synchronous fetching has been deprecated and should be switched
-=======
-// IDE_Morph synchronous HTTP data fetching
-IDE_Morph.prototype.getURL = function (url) {
->>>>>>> Improve save and share to show the save dialog for new projects
     var request = new XMLHttpRequest(),
         async = callback instanceof Function,
         myself = this;

--- a/gui.js
+++ b/gui.js
@@ -3478,7 +3478,6 @@ IDE_Morph.prototype.saveProject = function (name) {
 // Save a project and show a URL
 IDE_Morph.prototype.saveAndShare = function() {
     var myself = this,
-        projectName = this.projectName,
         projectDialog;
 
     function shareProject() {
@@ -3503,25 +3502,28 @@ IDE_Morph.prototype.saveAndShare = function() {
         );
         prompt(
             'This project is now public at the following URL:',
-            myself.publicProjectURL(myself.username, projectName)
+	    myself.publicProjectURL(SnapCloud.username, myself.projectName)
         );
     }
 
-    if (!projectName) {
+    if (!this.projectName) {
         projectDialog = new ProjectDialogMorph(this, 'save');
         // When a project it saved to the cloud, also share it.
         projectDialog.saveCloudProject = function () {
             myself.showMessage('Saving project\nto the cloud...');
-            SnapCloud.saveProject(myself, saveProject, myself.cloudError());
+	    SnapCloud.saveProject(
+		myself,
+		shareProject,
+		myself.cloudError());
             this.destroy();
         };
         projectDialog.popUp();
     } else {
         this.showMessage('Saving project\nto the cloud...');
-        this.setProjectName(projectName);
+	this.setProjectName(this.projectName);
         SnapCloud.saveProject(this, shareProject, this.cloudError());
     }
-}
+};
 
 // Serialize a project and save to the browser.
 IDE_Morph.prototype.rawSaveProject = function (name) {

--- a/gui.js
+++ b/gui.js
@@ -3478,10 +3478,11 @@ IDE_Morph.prototype.saveProject = function (name) {
 // Save a project and show a URL
 IDE_Morph.prototype.saveAndShare = function() {
     var myself = this,
+	world = this.world(),
 	projectDialog;
 
     function shareProject() {
-	var urlDialog, urlBox, alreadyPublic,
+	var dialog, frame, text, width,
 	    publicURL;
 
 	publicURL = myself.publicProjectURL(
@@ -3490,7 +3491,7 @@ IDE_Morph.prototype.saveAndShare = function() {
 	);
 
 	// only call Snap!Cloud if the project has needs to be shared
-	if (window.location !== publicURL) {
+	if (window.location.href !== publicURL) {
 	    myself.showMessage('sharing\nproject...');
 	    SnapCloud.reconnect(
 		function () {
@@ -3513,18 +3514,39 @@ IDE_Morph.prototype.saveAndShare = function() {
 	    );
 	}
 
-	urlDialog = new DialogBoxMorph();
-	urlDialog.labelString = 'Copy the public address:';
-	urlDialog.createLabel();
-	urlBox = new InputFieldMorph(publicURL);
-	urlBox.setWidth(300);
-	urlDialog.addBody(urlBox);
-	urlBox.drawNew();
-        urlDialog.addButton('ok', 'OK');
-        urlDialog.fixLayout();
-        urlDialog.drawNew();
-        urlDialog.fixLayout();
-        urlDialog.popUp(world);
+	dialog = new DialogBoxMorph().withKey('sharedURLDialog');
+	dialog.labelString = 'Copy the public address:';
+	dialog.createLabel();
+
+	frame = new ScrollFrameMorph(),
+	text = new StringMorph(publicURL),
+	width = 250,
+
+	frame.padding = 6;
+	frame.setWidth(width);
+	text.setWidth(width - frame.padding * 2);
+	text.setPosition(frame.topLeft().add(frame.padding));
+	text.enableSelecting();
+	text.isEditable = true;
+
+	frame.fixLayout = nop;
+	frame.edge = InputFieldMorph.prototype.edge;
+	frame.fontSize = InputFieldMorph.prototype.fontSize;
+	frame.typeInPadding = InputFieldMorph.prototype.typeInPadding;
+	frame.contrast = InputFieldMorph.prototype.contrast;
+	frame.drawNew = InputFieldMorph.prototype.drawNew;
+	frame.drawRectBorder = InputFieldMorph.prototype.drawRectBorder;
+
+	frame.addContents(text);
+	text.drawNew();
+	dialog.addBody(frame);
+	frame.drawNew();
+	dialog.addButton('ok', 'OK');
+	dialog.fixLayout();
+	dialog.drawNew();
+	dialog.popUp(world);
+	dialog.setCenter(world.center());
+	text.edit();
     }
 
     if (!this.projectName) {

--- a/gui.js
+++ b/gui.js
@@ -3475,78 +3475,78 @@ IDE_Morph.prototype.saveProject = function (name) {
     ]);
 };
 
-// Save a project and show a URL
-IDE_Morph.prototype.saveAndShare = function() {
+// Save a project and pop up a dialog with a copyable URL.
+IDE_Morph.prototype.saveAndShare = function () {
     var myself = this,
-	world = this.world(),
-	projectDialog;
+        world = this.world(),
+        projectDialog;
 
     function shareProject() {
-	var dialog, frame, text, width,
-	    publicURL;
+        var dialog, frame, text, width,
+            publicURL;
 
-	publicURL = myself.publicProjectURL(
-	    SnapCloud.username,
-	    myself.projectName
-	);
+        publicURL = myself.publicProjectURL(
+            SnapCloud.username,
+            myself.projectName
+        );
 
-	// only call Snap!Cloud if the project has needs to be shared
-	if (window.location.href !== publicURL) {
-	    myself.showMessage('sharing\nproject...');
-	    SnapCloud.reconnect(
-		function () {
-		    SnapCloud.callService(
-			'publishProject',
-			function () {
-			    myself.showMessage('shared.', 2);
-			    window.location.hash = (new URL(publicURL)).hash;
-			},
-			myself.cloudError(),
-			[
-			    myself.projectName,
-			    myself.stage.thumbnail(
-				SnapSerializer.prototype.thumbnailSize
-			    ).toDataURL('image/png')
-			]
-		    );
-		},
-		myself.cloudError()
-	    );
-	}
+        // only call Snap!Cloud if the project has needs to be shared
+        if (window.location.href !== publicURL) {
+            myself.showMessage('sharing\nproject...');
+            SnapCloud.reconnect(
+                function () {
+                    SnapCloud.callService(
+                        'publishProject',
+                        function () {
+                            myself.showMessage('shared.', 2);
+                            window.location.hash = (new URL(publicURL)).hash;
+                        },
+                        myself.cloudError(),
+                        [
+                            myself.projectName,
+                            myself.stage.thumbnail(
+                                SnapSerializer.prototype.thumbnailSize
+                            ).toDataURL('image/png')
+                        ]
+                    );
+                },
+                myself.cloudError()
+            );
+        }
 
-	dialog = new DialogBoxMorph().withKey('sharedURLDialog');
-	dialog.labelString = 'Copy the public address:';
-	dialog.createLabel();
+        dialog = new DialogBoxMorph().withKey('sharedURLDialog');
+        dialog.labelString = 'Copy the public address:';
+        dialog.createLabel();
 
-	frame = new ScrollFrameMorph(),
-	text = new StringMorph(publicURL),
-	width = 250,
+        frame = new ScrollFrameMorph(),
+        text = new StringMorph(publicURL),
+        width = 250,
 
-	frame.padding = 6;
-	frame.setWidth(width);
-	text.setWidth(width - frame.padding * 2);
-	text.setPosition(frame.topLeft().add(frame.padding));
-	text.enableSelecting();
-	text.isEditable = true;
+        frame.padding = 6;
+        frame.setWidth(width);
+        text.setWidth(width - frame.padding * 2);
+        text.setPosition(frame.topLeft().add(frame.padding));
+        text.enableSelecting();
+        text.isEditable = true;
 
-	frame.fixLayout = nop;
-	frame.edge = InputFieldMorph.prototype.edge;
-	frame.fontSize = InputFieldMorph.prototype.fontSize;
-	frame.typeInPadding = InputFieldMorph.prototype.typeInPadding;
-	frame.contrast = InputFieldMorph.prototype.contrast;
-	frame.drawNew = InputFieldMorph.prototype.drawNew;
-	frame.drawRectBorder = InputFieldMorph.prototype.drawRectBorder;
+        frame.fixLayout = nop;
+        frame.edge = InputFieldMorph.prototype.edge;
+        frame.fontSize = InputFieldMorph.prototype.fontSize;
+        frame.typeInPadding = InputFieldMorph.prototype.typeInPadding;
+        frame.contrast = InputFieldMorph.prototype.contrast;
+        frame.drawNew = InputFieldMorph.prototype.drawNew;
+        frame.drawRectBorder = InputFieldMorph.prototype.drawRectBorder;
 
-	frame.addContents(text);
-	text.drawNew();
-	dialog.addBody(frame);
-	frame.drawNew();
-	dialog.addButton('ok', 'OK');
-	dialog.fixLayout();
-	dialog.drawNew();
-	dialog.popUp(world);
-	dialog.setCenter(world.center());
-	text.edit();
+        frame.addContents(text);
+        text.drawNew();
+        dialog.addBody(frame);
+        frame.drawNew();
+        dialog.addButton('ok', 'OK');
+        dialog.fixLayout();
+        dialog.drawNew();
+        dialog.popUp(world);
+        dialog.setCenter(world.center());
+        text.edit();
     }
 
     if (!this.projectName) {
@@ -3554,7 +3554,7 @@ IDE_Morph.prototype.saveAndShare = function() {
         // When a project it saved to the cloud, also share it.
         projectDialog.saveCloudProject = function () {
             myself.showMessage('Saving project\nto the cloud...');
-	    SnapCloud.saveProject(myself, shareProject, myself.cloudError());
+            SnapCloud.saveProject(myself, shareProject, myself.cloudError());
             this.destroy();
         };
         projectDialog.popUp();


### PR DESCRIPTION
This builds of @bromagosa's work. There is a now an item in the file menu
which when selected will save the current project to the cloud, then will
present the user with a text box to copy the URL.

This makes the following changes from what's currently in BettleBlocks:
- If the project hasn't been saved yet, then show a save dialog box first
- Presenting the URL is now done with a native morphic dialog box! Now that
  C&P works well, this looks much nicer. :)
- Adds a new IDE method `publicProjectURL = function (username, projectName)`
  - This gives the public project URL. I'm probably going to use this to
    refactor some existing code for getting URLs later.

There are some TODO elements:
- [x] Definitely needs a thorough code review
- [x] The dialog box looks a bit off. I think I could use some pointers here...
- [ ] Until we have context menus, we probably want some text to tell people
  _how_ to copy text.
- [x] Don't make a cloud request for the "share" service if the project is
  already public
- [x] Update the browser's URL on successful sharing.

Deployed at http://snap.berkeley.edu/michael
