### PR TITLE
Add [scratchblocks] export

### DIFF
--- a/blocks.js
+++ b/blocks.js
@@ -2547,7 +2547,7 @@ BlockMorph.prototype.userMenu = function () {
         'userDestroy'
     );
     menu.addItem(
-      'stringify...',
+      'forum code...',
         function() {
             var code = myself.stringify();
             window.prompt('scratchblocks code for you to copy and paste', code);

--- a/blocks.js
+++ b/blocks.js
@@ -2547,7 +2547,7 @@ BlockMorph.prototype.userMenu = function () {
         'userDestroy'
     );
     menu.addItem(
-      'forum code...',
+      'scratchblocks code...',
         function() {
             var code = myself.toScratchblocks();
             window.prompt('scratchblocks code for you to copy and paste', code);

--- a/blocks.js
+++ b/blocks.js
@@ -1874,6 +1874,7 @@ SyntaxElementMorph.prototype.stringify = function () {
 
 SyntaxElementMorph.prototype.stringifyCategory = function () {
     // private. answers with scratchblocks category specifier
+    if (!this.category) return '';
     return ' :: ' + ({
         'lists': 'list',
         'other': 'grey',
@@ -6731,8 +6732,12 @@ ArgMorph.prototype.isEmptySlot = function () {
 // ArgMorph to "scratchblocks"
 
 ArgMorph.prototype.stringify = function () {
-    if (this.isHole) { // empty hole in ring
-        return this.isPredicate ? '< >' : '( )';
+    if (this.isHole) {
+        if (this.children[0] instanceof ArgMorph) {
+            return this.isPredicate ? '< >' : '( )';
+        } else {
+            return this.children[0].stringify();
+        }
     } else if (this.type === 'list') {
         return '[ ]'; // scratchblocks renderer does not have a "list" symbol
     }
@@ -8845,7 +8850,8 @@ TemplateSlotMorph.prototype.evaluate = function () {
 // TemplateSlotMorph to "scratchblocks"
 
 TemplateSlotMorph.prototype.stringify = function () {
-    return '(' + this.labelString + ')';
+    var category = this.parent.stringifyCategory() || ' :: grey';
+    return '(' + this.children[0].stringify() + category + ')';
 };
 
 // TemplateSlotMorph layout:
@@ -11436,13 +11442,17 @@ MultiArgMorph.prototype.removeInput = function () {
 
 MultiArgMorph.prototype.stringify = function () {
     var arrows = this.arrows().children,
-        inner;
-    inner = this.inputs().map(function(child) {
+        label = this.children[0],
+        result = '';
+    if (label.isVisible) {
+        result += label.text;
+    }
+    result += this.inputs().map(function(child) {
         return child.stringify();
     }).join(' ');
-    if (arrows[0].isVisible) inner += ' @delInput';
-    if (arrows[1].isVisible) inner += ' @addInput';
-    return inner;
+    if (arrows[0].isVisible) result += ' @delInput';
+    if (arrows[1].isVisible) result += ' @addInput';
+    return result;
 };
 
 // MultiArgMorph events:

--- a/blocks.js
+++ b/blocks.js
@@ -1854,25 +1854,25 @@ SyntaxElementMorph.prototype.isEmptySlot = function () {
 
 // SyntaxElementMorph to "scratchblocks"
 
-SyntaxElementMorph.prototype.stringify = function () {
+SyntaxElementMorph.prototype.toScratchblocks = function () {
     var nb = this.nextBlock && this.nextBlock(),
         result;
     result = this.parts().map(function(child) {
-        if (child.stringify) {
-          return child.stringify();
+        if (child.toScratchblocks) {
+          return child.toScratchblocks();
         } else if (child instanceof StringMorph) {
           return child.text;
         } else {
           return ''; // should never happen
         }
-    }).join(' ') + this.stringifyCategory();
+    }).join(' ') + this.toScratchblocksCategory();
     if (nb) {
-        result += '\n' + nb.stringify()
+        result += '\n' + nb.toScratchblocks()
     }
     return result;
 };
 
-SyntaxElementMorph.prototype.stringifyCategory = function () {
+SyntaxElementMorph.prototype.toScratchblocksCategory = function () {
     // private. answers with scratchblocks category specifier
     if (!this.category) return '';
     return ' :: ' + ({
@@ -2549,7 +2549,7 @@ BlockMorph.prototype.userMenu = function () {
     menu.addItem(
       'forum code...',
         function() {
-            var code = myself.stringify();
+            var code = myself.toScratchblocks();
             window.prompt('scratchblocks code for you to copy and paste', code);
         },
       'generate `scratchblocks` code for the Scratch Forums'
@@ -5096,8 +5096,8 @@ ReporterBlockMorph.prototype.determineSlotSpec = function () {
 
 // ReporterBlockMorph to "scratchblocks"
 
-ReporterBlockMorph.prototype.stringify = function () {
-    var inner = ReporterBlockMorph.uber.stringify.call(this);
+ReporterBlockMorph.prototype.toScratchblocks = function () {
+    var inner = ReporterBlockMorph.uber.toScratchblocks.call(this);
     if (this.isPredicate) {
         return '<' + inner + '>';
     } else {
@@ -5668,9 +5668,9 @@ RingMorph.prototype.fixBlockColor = function (nearest, isForced) {
 
 // RingMorph to "scratchblocks"
 
-RingMorph.prototype.stringifyCategory = function () {
+RingMorph.prototype.toScratchblocksCategory = function () {
     // force rendering as a 'ring' shape.
-    return RingMorph.uber.stringifyCategory.call(this) + ' ring';
+    return RingMorph.uber.toScratchblocksCategory.call(this) + ' ring';
 };
 
 
@@ -6731,12 +6731,12 @@ ArgMorph.prototype.isEmptySlot = function () {
 
 // ArgMorph to "scratchblocks"
 
-ArgMorph.prototype.stringify = function () {
+ArgMorph.prototype.toScratchblocks = function () {
     if (this.isHole) {
         if (this.children[0] instanceof ArgMorph) {
             return this.isPredicate ? '< >' : '( )';
         } else {
-            return this.children[0].stringify();
+            return this.children[0].toScratchblocks();
         }
     } else if (this.type === 'list') {
         return '[ ]'; // scratchblocks renderer does not have a "list" symbol
@@ -6893,9 +6893,9 @@ CommandSlotMorph.prototype.isEmptySlot = function () {
 
 // CommandSlotMorph to "scratchblocks"
 
-CommandSlotMorph.prototype.stringify = function () {
+CommandSlotMorph.prototype.toScratchblocks = function () {
     var inside = this.children.map(function(child) {
-        return child.stringify();
+        return child.toScratchblocks();
     }).join('\n');
     // need line break if empty
     // otherwise scratchblocks renders an empty embedded block
@@ -8481,7 +8481,7 @@ InputSlotMorph.prototype.isEmptySlot = function () {
 
 // InputSlotMorph to "scratchblocks"
 
-InputSlotMorph.prototype.stringify = function () {
+InputSlotMorph.prototype.toScratchblocks = function () {
     var contents = this.contents(),
         text = contents.text;
     if (this.isNumeric) {
@@ -8849,9 +8849,9 @@ TemplateSlotMorph.prototype.evaluate = function () {
 
 // TemplateSlotMorph to "scratchblocks"
 
-TemplateSlotMorph.prototype.stringify = function () {
-    var category = this.parent.stringifyCategory() || ' :: grey';
-    return '(' + this.children[0].stringify() + category + ')';
+TemplateSlotMorph.prototype.toScratchblocks = function () {
+    var category = this.parent.toScratchblocksCategory() || ' :: grey';
+    return '(' + this.children[0].toScratchblocks() + category + ')';
 };
 
 // TemplateSlotMorph layout:
@@ -9018,7 +9018,7 @@ BooleanSlotMorph.prototype.toggleValue = function () {
 
 // BooleanSlotMorph to "scratchblocks"
 
-BooleanSlotMorph.prototype.stringify = function () {
+BooleanSlotMorph.prototype.toScratchblocks = function () {
     if (this.value === null) {
       return '< >'; // empty boolean slot
     } else {
@@ -9707,7 +9707,7 @@ SymbolMorph.prototype.setLabelColor = function (
 
 // SymbolMorph to "scratchblocks"
 
-SymbolMorph.prototype.stringify = function () {
+SymbolMorph.prototype.toScratchblocks = function () {
     var symbol = {
         'flag': 'greenFlag',
     }[this.name] || this.name;
@@ -11440,7 +11440,7 @@ MultiArgMorph.prototype.removeInput = function () {
 
 // MultiArgMorph to "scratchblocks"
 
-MultiArgMorph.prototype.stringify = function () {
+MultiArgMorph.prototype.toScratchblocks = function () {
     var arrows = this.arrows().children,
         label = this.children[0],
         result = '';
@@ -11448,7 +11448,7 @@ MultiArgMorph.prototype.stringify = function () {
         result += label.text;
     }
     result += this.inputs().map(function(child) {
-        return child.stringify();
+        return child.toScratchblocks();
     }).join(' ');
     if (arrows[0].isVisible) result += ' @delInput';
     if (arrows[1].isVisible) result += ' @addInput';

--- a/blocks.js
+++ b/blocks.js
@@ -1874,7 +1874,7 @@ SyntaxElementMorph.prototype.toScratchblocks = function () {
 
 SyntaxElementMorph.prototype.toScratchblocksCategory = function () {
     // private. answers with scratchblocks category specifier
-    if (!this.category) return '';
+    if (!this.category) { return ''; }
     return ' :: ' + ({
         'lists': 'list',
         'other': 'grey',
@@ -2548,7 +2548,7 @@ BlockMorph.prototype.userMenu = function () {
     );
     menu.addItem(
       'scratchblocks code...',
-        function() {
+        function () {
             var code = myself.toScratchblocks();
             window.prompt('scratchblocks code for you to copy and paste', code);
         },

--- a/byob.js
+++ b/byob.js
@@ -870,7 +870,7 @@ CustomCommandBlockMorph.prototype.userMenu = function () {
         menu = new MenuMorph(this);
         menu.addItem(
             'scratchblocks code...',
-              function() {
+              function () {
                   var code = myself.parent.toScratchblocks();
                   window.prompt('scratchblocks code for you to copy and paste', code);
               },

--- a/byob.js
+++ b/byob.js
@@ -869,7 +869,7 @@ CustomCommandBlockMorph.prototype.userMenu = function () {
     if (this.isPrototype) {
         menu = new MenuMorph(this);
         menu.addItem(
-            'stringify...',
+            'forum code...',
               function() {
                   var code = myself.parent.stringify();
                   window.prompt('scratchblocks code for you to copy and paste', code);

--- a/byob.js
+++ b/byob.js
@@ -869,6 +869,14 @@ CustomCommandBlockMorph.prototype.userMenu = function () {
     if (this.isPrototype) {
         menu = new MenuMorph(this);
         menu.addItem(
+            'stringify...',
+              function() {
+                  var code = myself.parent.stringify();
+                  window.prompt('scratchblocks code for you to copy and paste', code);
+              },
+            'generate `scratchblocks` code for the Scratch Forums'
+        );
+        menu.addItem(
             "script pic...",
             function () {
                 var ide = this.world().children[0];
@@ -2187,6 +2195,19 @@ PrototypeHatBlockMorph.prototype.mouseClickLeft = function () {
 PrototypeHatBlockMorph.prototype.userMenu = function () {
     return this.parts()[0].userMenu();
 };
+          
+// PrototypeHatBlockMorph to "scratchblocks"
+
+PrototypeHatBlockMorph.prototype.stringify = function () {
+    var customCommand = this.parts()[0],
+        nb = this.nextBlock(),
+        result;
+    result = '{' + customCommand.stringify() + '} :: control hat';
+    if (nb) {
+      result += '\n' + nb.stringify();
+    }
+    return result;
+};
 
 // PrototypeHatBlockMorph zebra coloring
 
@@ -2526,6 +2547,12 @@ BlockLabelPlaceHolderMorph.prototype.init = function () {
     this.isHighlighted = false;
     this.isProtectedLabel = true; // doesn't participate in zebra coloring
     BlockLabelFragmentMorph.uber.init.call(this, '+');
+};
+
+// BlockLabelPlaceHolderMorph to "scratchblocks"
+
+BlockLabelPlaceHolderMorph.prototype.stringify = function () {
+    return ''; // don't include plusses in scratchblocks output
 };
 
 // BlockLabelPlaceHolderMorph drawing

--- a/byob.js
+++ b/byob.js
@@ -871,7 +871,7 @@ CustomCommandBlockMorph.prototype.userMenu = function () {
         menu.addItem(
             'forum code...',
               function() {
-                  var code = myself.parent.stringify();
+                  var code = myself.parent.toScratchblocks();
                   window.prompt('scratchblocks code for you to copy and paste', code);
               },
             'generate `scratchblocks` code for the Scratch Forums'
@@ -2198,13 +2198,13 @@ PrototypeHatBlockMorph.prototype.userMenu = function () {
           
 // PrototypeHatBlockMorph to "scratchblocks"
 
-PrototypeHatBlockMorph.prototype.stringify = function () {
+PrototypeHatBlockMorph.prototype.toScratchblocks = function () {
     var customCommand = this.parts()[0],
         nb = this.nextBlock(),
         result;
-    result = '{' + customCommand.stringify() + '} :: control hat';
+    result = '{' + customCommand.toScratchblocks() + '} :: control hat';
     if (nb) {
-      result += '\n' + nb.stringify();
+      result += '\n' + nb.toScratchblocks();
     }
     return result;
 };
@@ -2551,7 +2551,7 @@ BlockLabelPlaceHolderMorph.prototype.init = function () {
 
 // BlockLabelPlaceHolderMorph to "scratchblocks"
 
-BlockLabelPlaceHolderMorph.prototype.stringify = function () {
+BlockLabelPlaceHolderMorph.prototype.toScratchblocks = function () {
     return ''; // don't include plusses in scratchblocks output
 };
 

--- a/byob.js
+++ b/byob.js
@@ -869,7 +869,7 @@ CustomCommandBlockMorph.prototype.userMenu = function () {
     if (this.isPrototype) {
         menu = new MenuMorph(this);
         menu.addItem(
-            'forum code...',
+            'scratchblocks code...',
               function() {
                   var code = myself.parent.toScratchblocks();
                   window.prompt('scratchblocks code for you to copy and paste', code);


### PR DESCRIPTION
Good morning! :)

This is a small PR to add a "stringify..." option to the menu. This opens a dialog box containing [scratchblocks](https://wiki.scratch.mit.edu/wiki/Block_Plugin/Syntax) code, which can be copy/pasted into the [Scratch Forums](https://scratch.mit.edu/discuss/topic/219464/). (You can also try the [test page](https://scratchblocks.github.io), but since Snap! already has a "script pic" feature, the test page is less useful!)

Uploading pictures to the Snap! forums is quite time-consuming. Copy/pasting scratchblocks code is quicker, and might help to facilitate discussion on the User thread.

I've partly done this as an exercise in writing code in a Jens-approved style; please let me know what you think @jmoenig! :-)