### PR TITLE
Draw an import button in Costumes, Backgrounds and Sounds tabs

### DIFF
--- a/blocks.js
+++ b/blocks.js
@@ -9797,6 +9797,8 @@ SymbolMorph.prototype.symbolCanvasColored = function (aColor) {
         return this.drawSymbolFlash(canvas, aColor);
     case 'brush':
         return this.drawSymbolBrush(canvas, aColor);
+    case 'import':
+        return this.drawSymbolImport(canvas, aColor);
     case 'rectangle':
         return this.drawSymbolRectangle(canvas, aColor);
     case 'rectangleSolid':
@@ -10450,6 +10452,54 @@ SymbolMorph.prototype.drawSymbolFlash = function (canvas, color) {
     ctx.fill();
     return canvas;
 };
+
+SymbolMorph.prototype.drawSymbolImport = function(canvas, color) {
+    // answer a canvas showing a import icon
+    var ctx = canvas.getContext('2d'),
+        w = canvas.width,
+        h = canvas.height,
+        l = Math.max(w / 30, 0.5),
+        rw = w - 2,
+        rh = h - 4,
+        rx = 1,
+        ry = h - rh - 1,
+        r = 3,
+        hole = rw - 6,
+        ax = w / 2,
+        ay = h - 4,
+        aw = 3,
+        ah = 4;
+
+    ctx.lineWidth = l * 4;
+    ctx.lineJoin = 'round';
+    ctx.lineCap = 'round';
+    ctx.strokeStyle = color.darker().toString();
+    ctx.fillStyle = color.toString();
+
+    ctx.beginPath();
+    ctx.moveTo(rx + (rw + hole) / 2, ry);
+    ctx.lineTo(rx + rw - r, ry);
+    ctx.quadraticCurveTo(rx + rw, ry, rx + rw, ry + r, r);
+    ctx.lineTo(rx + rw, ry + rh - r);
+    ctx.quadraticCurveTo(rx + rw, ry + rh, rx + rw - r, ry + rh, r);
+    ctx.lineTo(rx + r, ry + rh);
+    ctx.quadraticCurveTo(rx, ry + rh, rx, ry + rh - r, r);
+    ctx.lineTo(rx, ry + r);
+    ctx.quadraticCurveTo(rx, ry, rx + r, ry, r);
+    ctx.lineTo(rx + (rw - hole) / 2, ry);
+    ctx.stroke();
+
+    ctx.strokeStyle = color.toString();
+    ctx.beginPath();
+    ctx.moveTo(ax, 0);
+    ctx.lineTo(ax, ay);
+    ctx.moveTo(ax + aw, ay - ah);
+    ctx.lineTo(ax, ay);
+    ctx.lineTo(ax - aw, ay - ah);
+    ctx.stroke();
+    return canvas;
+};
+
 
 SymbolMorph.prototype.drawSymbolBrush = function (canvas, color) {
     // answer a canvas showing a paintbrush

--- a/gui.js
+++ b/gui.js
@@ -7458,7 +7458,8 @@ WardrobeMorph.prototype.updateList = function () {
         icon,
         template,
         txt,
-        paintbutton;
+        paintbutton,
+        importbutton;
 
     this.changed();
     oldFlag = Morph.prototype.trackChanges;
@@ -7502,15 +7503,40 @@ WardrobeMorph.prototype.updateList = function () {
 
     this.addContents(paintbutton);
 
+    importbutton = new PushButtonMorph(
+        this,
+        "importNew",
+        new SymbolMorph("import", 15)
+    );
+    importbutton.padding = 0;
+    importbutton.corner = 12;
+    importbutton.color = IDE_Morph.prototype.groupColor;
+    importbutton.highlightColor = IDE_Morph.prototype.frameColor.darker(50);
+    importbutton.pressColor = importbutton.highlightColor;
+    importbutton.labelMinExtent = new Point(36, 18);
+    importbutton.labelShadowOffset = new Point(-1, -1);
+    importbutton.labelShadowColor = importbutton.highlightColor;
+    importbutton.labelColor = TurtleIconMorph.prototype.labelColor;
+    importbutton.contrast = this.buttonContrast;
+    importbutton.drawNew();
+    importbutton.hint = "Select a costume from the media library";
+    importbutton.setPosition(new Point(x, y));
+    importbutton.fixLayout();
+    importbutton.setCenter(icon.center());
+    importbutton.setLeft(paintbutton.right() + padding * 2);
+
+
+    this.addContents(importbutton);
+
     txt = new TextMorph(localize(
         "costumes tab help" // look up long string in translator
     ));
-    txt.fontSize = 9;
-    txt.setColor(SpriteMorph.prototype.paletteTextColor);
+    txt.fontSize = 12;
+    txt.setColor(SpriteMorph.prototype.paletteTextColor.darker());
 
-    txt.setPosition(new Point(x, y));
+    txt.setPosition(new Point(importbutton.right() + padding * 6, importbutton.top() - 4));
     this.addContents(txt);
-    y = txt.bottom() + padding;
+    y = icon.bottom() + padding;
 
 
     this.sprite.costumes.asArray().forEach(function (costume) {
@@ -7568,6 +7594,13 @@ WardrobeMorph.prototype.paintNew = function () {
             ide.currentSprite.wearCostume(cos);
         }
     });
+};
+
+WardrobeMorph.prototype.importNew = function () {
+    var ide = this.parentThatIsA(IDE_Morph);
+    graphicsName = ide.currentSprite instanceof SpriteMorph ?
+                'Costumes' : 'Backgrounds'
+    ide.importMedia(graphicsName);
 };
 
 // Wardrobe drag & drop
@@ -7813,6 +7846,7 @@ JukeboxMorph.prototype = new ScrollFrameMorph();
 JukeboxMorph.prototype.constructor = JukeboxMorph;
 JukeboxMorph.uber = ScrollFrameMorph.prototype;
 
+
 function JukeboxMorph(aSprite, sliderColor) {
     this.init(aSprite, sliderColor);
 }
@@ -7832,6 +7866,10 @@ JukeboxMorph.prototype.init = function (aSprite, sliderColor) {
     this.updateList();
 };
 
+JukeboxMorph.prototype.importNew = function () {
+    this.parentThatIsA(IDE_Morph).importMedia('Sounds');
+};
+
 // Jukebox updating
 
 JukeboxMorph.prototype.updateList = function () {
@@ -7842,7 +7880,8 @@ JukeboxMorph.prototype.updateList = function () {
         oldFlag = Morph.prototype.trackChanges,
         icon,
         template,
-        txt;
+        txt,
+        importbutton;
 
     this.changed();
     oldFlag = Morph.prototype.trackChanges;
@@ -7856,12 +7895,34 @@ JukeboxMorph.prototype.updateList = function () {
     };
     this.addBack(this.contents);
 
+    importbutton = new PushButtonMorph(
+        this,
+        "importNew",
+        new SymbolMorph("import", 15)
+    );
+    importbutton.padding = 0;
+    importbutton.corner = 12;
+    importbutton.color = IDE_Morph.prototype.groupColor;
+    importbutton.highlightColor = IDE_Morph.prototype.frameColor.darker(50);
+    importbutton.pressColor = importbutton.highlightColor;
+    importbutton.labelMinExtent = new Point(36, 18);
+    importbutton.labelShadowOffset = new Point(-1, -1);
+    importbutton.labelShadowColor = importbutton.highlightColor;
+    importbutton.labelColor = TurtleIconMorph.prototype.labelColor;
+    importbutton.contrast = this.buttonContrast;
+    importbutton.drawNew();
+    importbutton.hint = "Select a sound from the media library";
+    importbutton.setPosition(new Point(x, y + padding));
+    importbutton.fixLayout();
+    this.addContents(importbutton);
+
+
     txt = new TextMorph(localize(
         'import a sound from your computer\nby dragging it into here'
     ));
-    txt.fontSize = 9;
-    txt.setColor(SpriteMorph.prototype.paletteTextColor);
-    txt.setPosition(new Point(x, y));
+    txt.fontSize = 12;
+    txt.setColor(SpriteMorph.prototype.paletteTextColor.darker());
+    txt.setPosition(new Point(importbutton.right() + padding * 6, y));
     this.addContents(txt);
     y = txt.bottom() + padding;
 

--- a/gui.js
+++ b/gui.js
@@ -7234,7 +7234,7 @@ CostumeIconMorph.prototype.removeCostume = function () {
     var wardrobe = this.parentThatIsA(WardrobeMorph),
         idx = this.parent.children.indexOf(this),
         ide = this.parentThatIsA(IDE_Morph);
-    wardrobe.removeCostumeAt(idx - 2);
+    wardrobe.removeCostumeAt(idx - 3);
     if (ide.currentSprite.costume === this.object) {
         ide.currentSprite.wearCostume(null);
     }

--- a/gui.js
+++ b/gui.js
@@ -7525,7 +7525,6 @@ WardrobeMorph.prototype.updateList = function () {
     importbutton.setCenter(icon.center());
     importbutton.setLeft(paintbutton.right() + padding * 2);
 
-
     this.addContents(importbutton);
 
     txt = new TextMorph(localize(
@@ -7845,7 +7844,6 @@ SoundIconMorph.prototype.prepareToBeGrabbed = function () {
 JukeboxMorph.prototype = new ScrollFrameMorph();
 JukeboxMorph.prototype.constructor = JukeboxMorph;
 JukeboxMorph.uber = ScrollFrameMorph.prototype;
-
 
 function JukeboxMorph(aSprite, sliderColor) {
     this.init(aSprite, sliderColor);

--- a/gui.js
+++ b/gui.js
@@ -1416,6 +1416,7 @@ IDE_Morph.prototype.createCorralBar = function () {
     var padding = 5,
         newbutton,
         paintbutton,
+        importbutton,
         colors = [
             this.groupColor,
             this.frameColor.darker(50),
@@ -1477,6 +1478,29 @@ IDE_Morph.prototype.createCorralBar = function () {
         this.corralBar.left() + padding + newbutton.width() + padding
     );
     this.corralBar.add(paintbutton);
+
+    importbutton = new PushButtonMorph(
+        this,
+        "addNewSpriteFromLibrary",
+        new SymbolMorph("import", 15)
+    );
+    importbutton.padding = 0;
+    importbutton.corner = 12;
+    importbutton.color = colors[0];
+    importbutton.highlightColor = colors[1];
+    importbutton.pressColor = colors[2];
+    importbutton.labelMinExtent = new Point(36, 18);
+    importbutton.labelShadowOffset = new Point(-1, -1);
+    importbutton.labelShadowColor = colors[1];
+    importbutton.labelColor = this.buttonLabelColor;
+    importbutton.contrast = this.buttonContrast;
+    importbutton.drawNew();
+    importbutton.hint = "add a new sprite";
+    importbutton.fixLayout();
+    importbutton.setCenter(this.corralBar.center());
+    importbutton.setLeft(paintbutton.right() + padding);
+    this.corralBar.add(importbutton);
+
 };
 
 IDE_Morph.prototype.createCorral = function () {
@@ -2093,6 +2117,19 @@ IDE_Morph.prototype.removeSetting = function (key) {
 };
 
 // IDE_Morph sprite list access
+
+IDE_Morph.prototype.addNewSpriteFromLibrary = function () {
+    var sprite = new SpriteMorph(this.globalVariables),
+        rnd = Process.prototype.reportRandom;
+
+    sprite.name = this.newSpriteName(sprite.name);
+    sprite.setCenter(this.stage.center());
+    this.stage.add(sprite);
+    this.sprites.add(sprite);
+    this.corral.addSprite(sprite);
+    this.selectSprite(sprite);
+    this.importMedia("Costumes");
+};
 
 IDE_Morph.prototype.addNewSprite = function () {
     var sprite = new SpriteMorph(this.globalVariables),

--- a/lang-fr.js
+++ b/lang-fr.js
@@ -671,6 +671,10 @@ SnapTranslator.dict.fr = {
         'importer un projet export\u00E9,\nune biblioth\u00E8que de '
             + 'blocs\n'
             + 'un costume ou un son',
+    'Select a sound from the media library':
+        'Selectionner un son dans la bibliothèque de médias.',
+    'Select a costume from the media library':
+        'Selectionner un costume dans la bibliothèque de médias.',
     'Export project as plain text...':
         'Exporter le projet comme texte...',
     'Export project...':


### PR DESCRIPTION
There is an import menu item, but I thought it would be nice to give young students another way to import medias from library...

That's why I added a button in Costumes/Backgrounds/ Sounds tabs : 

![importbutton](https://cloud.githubusercontent.com/assets/15179356/23182359/9454ec6c-f878-11e6-8aa6-5d53724eb103.png)

It's possible to see it here : 
http://db-maths.nuxit.net/snap/snap.html
