### PR TITLE
Fixing issue translating projectName only in the first language change

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -918,8 +918,9 @@ IDE_Morph.prototype.createControlBar = function () {
             return;
         }
 
+		if (!myself.projectName) myself.projectName = localize('untitled');
         this.label = new StringMorph(
-            (myself.projectName || localize('untitled')) + suffix,
+            myself.projectName + suffix,
             14,
             'sans-serif',
             true,


### PR DESCRIPTION
Hi again,
## Issue -Current behaviour
  - Starting up Snap! does a global localization (right of course!), also setting default project name (_localize('untitle')_)
  - When I change the language, IDE is translated, but not current project (I think this is fine). For example, sprites names don't change, even if I have the default sprite name (Sprite, Objekt, Objecte...)
  - But there is a curious behaviour with Project Name. In the first change it is translated (untitle, Unbenannt, Sense títol...) and after this (this first change), it is not translated anymore.

## Origin and Proposal
  - The problem is that the startup  is not defining _projectName_. After this, when I change language, _projectName_ is defined.
  - I think the right behaviour is, like sprite names, not translate projectName after startup.
  - My proposal is **to set projectName value in the first writting (in the startup)**.

Thanks,
Joan