### PR TITLE
Add basic logging code from iSnap

### DIFF
--- a/cloud.js
+++ b/cloud.js
@@ -36,7 +36,8 @@ modules.cloud = '2015-December-15';
 
 var Cloud;
 var SnapCloud = new Cloud(
-    'https://snap.apps.miosoft.com/SnapCloud'
+    // Allow the config file to override the Snap Cloud URL
+    window.snapCloudURL || 'https://snap.apps.miosoft.com/SnapCloud'
 );
 
 // Cloud /////////////////////////////////////////////////////////////

--- a/gui.js
+++ b/gui.js
@@ -262,6 +262,8 @@ IDE_Morph.prototype.init = function (isAutoFill) {
 };
 
 IDE_Morph.prototype.openIn = function (world) {
+    Trace.log('IDE.opened');
+
     var hash, usr, myself = this, urlLanguage = null;
 
     // get persistent user data, if any
@@ -936,6 +938,15 @@ IDE_Morph.prototype.createControlBar = function () {
     };
 };
 
+IDE_Morph.prototype.changeCategory = function (category) {
+    Trace.log('IDE.changeCategory', category);
+    this.currentCategory = category;
+    this.categories.children.forEach(function (each) {
+        each.refresh();
+    });
+    this.refreshPalette(true);
+};
+
 IDE_Morph.prototype.createCategories = function () {
     var myself = this;
 
@@ -959,11 +970,7 @@ IDE_Morph.prototype.createCategories = function () {
             colors,
             myself, // the IDE is the target
             function () {
-                myself.currentCategory = category;
-                myself.categories.children.forEach(function (each) {
-                    each.refresh();
-                });
-                myself.refreshPalette(true);
+                myself.changeCategory(category);
             },
             category[0].toUpperCase().concat(category.slice(1)), // label
             function () {  // query
@@ -1063,6 +1070,7 @@ IDE_Morph.prototype.createPalette = function (forSearching) {
             myself.currentSprite.wearCostume(null);
             droppedMorph.perish();
         } else if (droppedMorph instanceof BlockMorph) {
+            Trace.log('Block.dragDestroy', droppedMorph.blockId());
             if (hand && hand.grabOrigin.origin instanceof ScriptsMorph) {
                 hand.grabOrigin.origin.clearDropInfo();
                 hand.grabOrigin.origin.lastDroppedBlock = droppedMorph;
@@ -1149,6 +1157,7 @@ IDE_Morph.prototype.createSpriteBar = function () {
             myself, // the IDE is the target
             function () {
                 if (myself.currentSprite instanceof SpriteMorph) {
+                    Trace.log('IDE.rotationStyleChanged', rotationStyle);
                     myself.currentSprite.rotationStyle = rotationStyle;
                     myself.currentSprite.changed();
                     myself.currentSprite.drawNew();
@@ -1232,6 +1241,8 @@ IDE_Morph.prototype.createSpriteBar = function () {
         function () {
             myself.currentSprite.isDraggable =
                 !myself.currentSprite.isDraggable;
+            Trace.log('IDE.setSpriteDraggable',
+                myself.currentSprite.isDraggable);
         },
         localize('draggable'),
         function () {
@@ -1260,6 +1271,7 @@ IDE_Morph.prototype.createSpriteBar = function () {
 
     // tab bar
     tabBar.tabTo = function (tabString) {
+        Trace.log('IDE.setSpriteTab', tabString);
         var active;
         myself.currentTab = tabString;
         this.children.forEach(function (each) {
@@ -1891,13 +1903,16 @@ IDE_Morph.prototype.stopFastTracking = function () {
 };
 
 IDE_Morph.prototype.runScripts = function () {
+    Trace.log('IDE.greenFlag');
     this.stage.fireGreenFlagEvent();
 };
 
 IDE_Morph.prototype.togglePauseResume = function () {
     if (this.stage.threads.isPaused()) {
+        Trace.log('IDE.unpause');
         this.stage.threads.resumeAll(this.stage);
     } else {
+        Trace.log('IDE.pause');
         this.stage.threads.pauseAll(this.stage);
     }
     this.controlBar.pauseButton.refresh();
@@ -1909,6 +1924,7 @@ IDE_Morph.prototype.isPaused = function () {
 };
 
 IDE_Morph.prototype.stopAllScripts = function () {
+    Trace.log('IDE.stop');
     if (this.stage.enableCustomHatBlocks) {
         this.stage.threads.pauseCustomHatBlocks =
             !this.stage.threads.pauseCustomHatBlocks;
@@ -1920,6 +1936,7 @@ IDE_Morph.prototype.stopAllScripts = function () {
 };
 
 IDE_Morph.prototype.selectSprite = function (sprite) {
+    Trace.log('IDE.selectSprite', sprite.name);
     if (this.currentSprite && this.currentSprite.scripts.focus) {
         this.currentSprite.scripts.focus.stopEditing();
     }
@@ -2099,6 +2116,7 @@ IDE_Morph.prototype.addNewSprite = function () {
         rnd = Process.prototype.reportRandom;
 
     sprite.name = this.newSpriteName(sprite.name);
+    Trace.log('IDE.addSprite', sprite.name);
     sprite.setCenter(this.stage.center());
     this.stage.add(sprite);
 
@@ -2120,6 +2138,7 @@ IDE_Morph.prototype.paintNewSprite = function () {
         myself = this;
 
     sprite.name = this.newSpriteName(sprite.name);
+    Trace.log('IDE.paintNewSprite', sprite.name);
     sprite.setCenter(this.stage.center());
     this.stage.add(sprite);
     this.sprites.add(sprite);
@@ -2139,6 +2158,7 @@ IDE_Morph.prototype.paintNewSprite = function () {
 
 IDE_Morph.prototype.duplicateSprite = function (sprite) {
     var duplicate = sprite.fullCopy();
+    Trace.log('IDE.duplicateSprite', sprite.name);
 
     duplicate.setPosition(this.world().hand.position());
     duplicate.appearIn(this);
@@ -2147,6 +2167,7 @@ IDE_Morph.prototype.duplicateSprite = function (sprite) {
 };
 
 IDE_Morph.prototype.removeSprite = function (sprite) {
+    Trace.log('IDE.removeSprite', sprite.name);
     var idx, myself = this;
     sprite.parts.forEach(function (part) {myself.removeSprite(part); });
     idx = this.sprites.asArray().indexOf(sprite) + 1;
@@ -3397,6 +3418,7 @@ IDE_Morph.prototype.editProjectNotes = function () {
 };
 
 IDE_Morph.prototype.newProject = function () {
+    Trace.log('IDE.newProject');
     this.source = SnapCloud.username ? 'cloud' : 'local';
     if (this.stage) {
         this.stage.destroy();
@@ -3441,6 +3463,7 @@ IDE_Morph.prototype.save = function () {
 };
 
 IDE_Morph.prototype.saveProject = function (name) {
+    Trace.log('IDE.saveProject', name);
     var myself = this;
     this.nextSteps([
         function () {
@@ -3475,10 +3498,10 @@ IDE_Morph.prototype.rawSaveProject = function (name) {
     }
 };
 
-
 IDE_Morph.prototype.exportProject = function (name, plain, newWindow) {
     // Export project XML, saving a file to disk
     // newWindow requests displaying the project in a new tab.
+    Trace.log('IDE.exportProject', name);
     var menu, str, dataPrefix;
 
     if (name) {
@@ -3502,6 +3525,7 @@ IDE_Morph.prototype.exportProject = function (name, plain, newWindow) {
 };
 
 IDE_Morph.prototype.exportGlobalBlocks = function () {
+    Trace.log('IDE.exportGlobalBlocks');
     if (this.stage.globalBlocks.length > 0) {
         new BlockExportDialogMorph(
             this.serializer,
@@ -3555,6 +3579,7 @@ IDE_Morph.prototype.removeUnusedBlocks = function () {
 };
 
 IDE_Morph.prototype.exportSprite = function (sprite) {
+    Trace.log('IDE.exportSprite', sprite.name);
     var str = this.serializer.serialize(sprite.allParts());
     str = '<sprites app="'
         + this.serializer.app
@@ -3567,6 +3592,7 @@ IDE_Morph.prototype.exportSprite = function (sprite) {
 };
 
 IDE_Morph.prototype.exportScriptsPicture = function () {
+    Trace.log('IDE.exportScriptsPicture');
     var pics = [],
         pic,
         padding = 20,
@@ -3898,6 +3924,7 @@ IDE_Morph.prototype.exportProjectSummary = function (useDropShadows) {
 };
 
 IDE_Morph.prototype.openProjectString = function (str) {
+    Trace.log('IDE.openProjectString');
     var msg,
         myself = this;
     this.nextSteps([
@@ -3932,6 +3959,7 @@ IDE_Morph.prototype.rawOpenProjectString = function (str) {
             );
         } catch (err) {
             this.showMessage('Load failed: ' + err);
+            Trace.logError(err);
         }
     } else {
         this.serializer.openProject(
@@ -3943,6 +3971,7 @@ IDE_Morph.prototype.rawOpenProjectString = function (str) {
 };
 
 IDE_Morph.prototype.openCloudDataString = function (str) {
+    Trace.log('IDE.openCloudDataString');
     var msg,
         myself = this,
         size = Math.round(str.length / 1024);
@@ -3982,6 +4011,7 @@ IDE_Morph.prototype.rawOpenCloudDataString = function (str) {
             );
         } catch (err) {
             this.showMessage('Load failed: ' + err);
+            Trace.logError(err);
         }
     } else {
         model = this.serializer.parse(str);
@@ -3998,6 +4028,7 @@ IDE_Morph.prototype.rawOpenCloudDataString = function (str) {
 };
 
 IDE_Morph.prototype.openBlocksString = function (str, name, silently) {
+    Trace.log('IDE.openBlocksString');
     var msg,
         myself = this;
     this.nextSteps([
@@ -4023,6 +4054,7 @@ IDE_Morph.prototype.rawOpenBlocksString = function (str, name, silently) {
             blocks = this.serializer.loadBlocks(str, myself.stage);
         } catch (err) {
             this.showMessage('Load failed: ' + err);
+            Trace.logError(err);
         }
     } else {
         blocks = this.serializer.loadBlocks(str, myself.stage);
@@ -4030,6 +4062,7 @@ IDE_Morph.prototype.rawOpenBlocksString = function (str, name, silently) {
     if (silently) {
         blocks.forEach(function (def) {
             def.receiver = myself.stage;
+            def.isImported = true;
             myself.stage.globalBlocks.push(def);
             myself.stage.replaceDoubleDefinitionsFor(def);
         });
@@ -4045,6 +4078,7 @@ IDE_Morph.prototype.rawOpenBlocksString = function (str, name, silently) {
 };
 
 IDE_Morph.prototype.openSpritesString = function (str) {
+    Trace.log('IDE.openSpritesString');
     var msg,
         myself = this;
     this.nextSteps([
@@ -4067,6 +4101,7 @@ IDE_Morph.prototype.rawOpenSpritesString = function (str) {
             this.serializer.loadSprites(str, this);
         } catch (err) {
             this.showMessage('Load failed: ' + err);
+            Trace.logError(err);
         }
     } else {
         this.serializer.loadSprites(str, this);
@@ -4074,11 +4109,13 @@ IDE_Morph.prototype.rawOpenSpritesString = function (str) {
 };
 
 IDE_Morph.prototype.openMediaString = function (str) {
+    Trace.log('IDE.openMediaString');
     if (Process.prototype.isCatchingErrors) {
         try {
             this.serializer.loadMedia(str);
         } catch (err) {
             this.showMessage('Load failed: ' + err);
+            Trace.logError(err);
         }
     } else {
         this.serializer.loadMedia(str);
@@ -4087,6 +4124,7 @@ IDE_Morph.prototype.openMediaString = function (str) {
 };
 
 IDE_Morph.prototype.openProject = function (name) {
+    Trace.log('IDE.openProject', name);
     var str;
     if (name) {
         this.showMessage('opening project\n' + name);
@@ -4426,6 +4464,7 @@ IDE_Morph.prototype.toggleAppMode = function (appMode) {
         ];
 
     this.isAppMode = isNil(appMode) ? !this.isAppMode : appMode;
+    Trace.log('IDE.toggleAppMode', this.isAppMode);
 
     Morph.prototype.trackChanges = false;
     if (this.isAppMode) {
@@ -4487,6 +4526,7 @@ IDE_Morph.prototype.toggleStageSize = function (isSmall, forcedRatio) {
 
     function toggle() {
         myself.isSmallStage = isNil(isSmall) ? !myself.isSmallStage : isSmall;
+        Trace.log('IDE.toggleStageSize', myself.isSmallStage);
     }
 
     function zoomTo(targetRatio) {
@@ -4590,6 +4630,7 @@ IDE_Morph.prototype.languageMenu = function () {
 };
 
 IDE_Morph.prototype.setLanguage = function (lang, callback) {
+    Trace.log('IDE.setLanguage', lang);
     var translation = document.getElementById('language'),
         src = this.resourceURL('lang-' + lang + '.js'),
         myself = this;
@@ -4998,6 +5039,7 @@ IDE_Morph.prototype.logout = function () {
 };
 
 IDE_Morph.prototype.saveProjectToCloud = function (name) {
+    Trace.log('IDE.saveProjectToCloud', name);
     var myself = this;
     if (name) {
         this.showMessage('Saving project\nto the cloud...');
@@ -5011,6 +5053,7 @@ IDE_Morph.prototype.saveProjectToCloud = function (name) {
 };
 
 IDE_Morph.prototype.exportProjectMedia = function (name) {
+    Trace.log('IDE.exportProjectMedia', name);
     var menu, media;
     this.serializer.isCollectingMedia = true;
     if (name) {
@@ -5036,6 +5079,7 @@ IDE_Morph.prototype.exportProjectMedia = function (name) {
 };
 
 IDE_Morph.prototype.exportProjectNoMedia = function (name) {
+    Trace.log('IDE.exportProjectMedia', name);
     var menu, str;
     this.serializer.isCollectingMedia = true;
     if (name) {
@@ -5064,6 +5108,7 @@ IDE_Morph.prototype.exportProjectNoMedia = function (name) {
 };
 
 IDE_Morph.prototype.exportProjectAsCloudData = function (name) {
+    Trace.log('IDE.exportProejctAsCloudData', name);
     var menu, str, media, dta;
     this.serializer.isCollectingMedia = true;
     if (name) {
@@ -5311,6 +5356,7 @@ function ProjectDialogMorph(ide, label) {
 }
 
 ProjectDialogMorph.prototype.init = function (ide, task) {
+    Trace.log('ProjectDialog.shown');
     var myself = this;
 
     // additional properties:
@@ -5653,6 +5699,7 @@ ProjectDialogMorph.prototype.buildFilterField = function () {
 // ProjectDialogMorph ops
 
 ProjectDialogMorph.prototype.setSource = function (source) {
+    Trace.log('ProjectDialog.setSource', source);
     var myself = this,
         msg;
 

--- a/logging/.gitignore
+++ b/logging/.gitignore
@@ -1,0 +1,1 @@
+config.js

--- a/logging/config.js.example
+++ b/logging/config.js.example
@@ -1,0 +1,10 @@
+
+
+// Specify to override the default Snap cloud URL
+// window.snapCloudURL = 'https://snap.apps.miosoft.com/SnapCloud';
+
+// Create the logger you want to use on this snap deployment
+window.createLogger = function() {
+    // Logs to the console
+    return new window.ConsoleLogger(50);
+};

--- a/logging/console-logger.js
+++ b/logging/console-logger.js
@@ -1,0 +1,16 @@
+// Log to the console
+
+ConsoleLogger.prototype = Object.create(Logger.prototype);
+
+function ConsoleLogger(interval) {
+    Logger.call(this, interval);
+}
+
+ConsoleLogger.prototype.storeMessages = function(logs) {
+    var myself = this;
+    logs.forEach(function(log) {
+        log.userInfo = myself.userInfo();
+        // eslint-disable-next-line no-console
+        console.log(log);
+    });
+};

--- a/logging/logger.js
+++ b/logging/logger.js
@@ -1,0 +1,216 @@
+// Logger classes
+
+function Logger(interval) {
+    this.init(interval);
+}
+
+Logger.prototype.serializer = new SnapSerializer();
+
+Logger.prototype.init = function(interval) {
+    this.queue = [];
+    this.onCodeChanged = null;
+    this.log('Logger.started');
+    this.start(interval);
+    this.forceLogCode = false;
+    if (!Logger.sessionID) {
+        Logger.sessionID = newGuid();
+    }
+};
+
+// Get user identifying user info and bundle it as an object
+Logger.prototype.userInfo = function() {
+    var browserID = null;
+    // browser ID stored in cache or local storage
+    if (typeof(Storage) !== 'undefined' && localStorage) {
+        browserID = localStorage.getItem('browserID');
+        if (!browserID) {
+            browserID = newGuid();
+            localStorage.setItem('browserID', browserID);
+        }
+    }
+    return {
+        'sessionID': Logger.sessionID,
+        'browserID': browserID,
+    };
+};
+
+Logger.prototype.flushSaveCode = function() {
+    // If we have a pending saveCode function, run it and cancel the callback
+    if (this.saveCode) {
+        this.saveCode();
+        if (this.saveCodeTimeout) {
+            clearTimeout(this.saveCodeTimeout);
+            this.saveCodeTimeout = null;
+        }
+    }
+};
+
+/**
+ * Logs a message. Depending on the logger being used, the message
+ * may be output to the console or sent to be stored in a database.
+ *
+ * @this {Logger}
+ * @param {string} message The message to be logged. This is usually
+ * of the form '[Class].[action]', e.g. 'Logger.started', 'IDE.selectSprite'
+ * or 'Block.snapped'
+ * @param {object} data A javascript object to be logged in its entirety. Be
+ * careful not to pass large objects here.
+ * @param {boolean} saveImmediately If true, the code state will be saved
+ * immediately. By default, the code is saved on the next frame, allowing
+ * logging calls to capture code changes that occur immediately the logging
+ * statement. For example, this allows a logging statement to come at the
+ * beginning of a method which alters the code, and have that state change
+ * still captured.
+ * @param {boolean} forceLogCode Forces the logger to log the code state, even
+ * if unchanged.
+ */
+Logger.prototype.log = function(message, data, saveImmediately, forceLogCode) {
+    if (!(message || data)) return;
+
+    this.flushSaveCode();
+
+    var log = {
+        'message': message,
+        'data': data,
+        'time': Date.now(),
+    };
+
+    this.forceLogCode |= forceLogCode;
+
+    // Set a callback to save the code state in 1ms
+    // This allows us to call log() at the beginning of a method
+    // and save the code after it's finished executing
+    // (or before the next log() call, per the code above)
+    var myself = this;
+    this.saveCode = function() {
+        myself.saveCode = null;
+        myself.addCode(log);
+    };
+    // If saveImmediately is true, we just run it now
+    if (saveImmediately) {
+        this.saveCode();
+    } else {
+        this.saveCodeTimeout = setTimeout(this.saveCode, 1);
+    }
+
+    this.queue.push(log);
+};
+
+// Log a message as an error
+Logger.prototype.logErrorMessage = function(error) {
+    if (!error || !error.length) return;
+    var maxLength = 5000;
+    if (error.length > maxLength) {
+        error = error.substring(0, maxLength) + '...';
+    }
+    try {
+        // Have to actually throw the error for .stack to show up on IE
+        throw new Error(error);
+    } catch (e) {
+        this.logError(e);
+    }
+};
+
+// Log a javascript error
+Logger.prototype.logError = function(error) {
+    if (!error) return;
+    // eslint-disable-next-line no-console
+    console.error(error);
+    this.log('Error', {
+        'message': error.message,
+        'url': error.fileName,
+        'line': error.lineNumber,
+        'column': error.columnNumber,
+        'stack': error.stack,
+        'browser': this.getBrowser(),
+    });
+};
+
+// Credit: http://stackoverflow.com/a/9851769/816458
+Logger.prototype.getBrowser = function() {
+    try {
+        if (!!window.opera || navigator.userAgent.indexOf(' OPR/') >= 0) {
+            return 'Opera';
+        }
+        // Opera 8.0+ (UA detection to detect Blink/v8-powered Opera)
+        if (typeof InstallTrigger !== 'undefined') return 'Firefox';
+        // At least Safari 3+: '[object HTMLElementConstructor]'
+        if (Object.prototype.toString.call(window.HTMLElement)
+                .indexOf('Constructor') > 0) {
+            return 'Safari';
+        }
+        // Chrome 1+
+        if (window.chrome) return 'Chrome';
+        // At least IE6
+        if (/*@cc_on!@*/false || !!document.documentMode) return 'IE';
+    } catch (e) {
+        // empty
+    }
+    return null;
+};
+
+Logger.prototype.addCode = function(log) {
+    var ide = world.children[0];
+    if (typeof(ide) == 'undefined' || !ide.stage) return;
+    log.projectID = ide.stage.guid;
+    var code = this.serializer.serialize(ide.stage);
+    code = this.removeImages(code);
+
+    if (this.forceLogCode || this.hasCodeChanged(this.lastCode, code)) {
+        this.forceLogCode = false;
+        log.code = code;
+        this.lastCode = code;
+        if (this.onCodeChanged) this.onCodeChanged(code);
+    }
+};
+
+Logger.prototype.removeCoordinates = function(xml) {
+    if (!xml) return xml;
+    // Remove the tags that have coordinates (and nothing else of interest)
+    return xml.replace(/<(sprite|stage|watcher|script) [^>]*>/g, '');
+};
+
+Logger.prototype.hasCodeChanged = function(xml1, xml2) {
+    // Remove coordinates before comparing code, since we don't need to
+    // log these unimportant changes to the code state
+    return this.removeCoordinates(xml1) !== this.removeCoordinates(xml2);
+};
+
+Logger.prototype.storeMessages = function(logs) {
+
+};
+
+/**
+ * Stops the logger from posting messages.
+ * Messages can still be logged and will post
+ * when the logger is started.
+ *
+ * @this {Logger}
+ */
+Logger.prototype.stop = function() {
+    clearInterval(this.storeCallback);
+};
+
+/**
+ * Starts the logger. Messages will be posted
+ * at the provided interval.
+ *
+ * @param {int} interval The interval at which to post
+ * logged messages.
+ */
+Logger.prototype.start = function(interval) {
+    if (!interval) return;
+    var myself = this;
+    this.storeCallback = setInterval(function() {
+        if (myself.queue.length == 0) return;
+        myself.flushSaveCode();
+        myself.storeMessages(myself.queue);
+        myself.queue = [];
+    }, interval);
+};
+
+Logger.prototype.removeImages = function(xml) {
+    if (!xml) return xml;
+    // We don't want to log the stage image every time
+    return xml.replace(/data:image\/png;base64[^<\"]*/g, '');
+};

--- a/logging/main.js
+++ b/logging/main.js
@@ -1,0 +1,35 @@
+var Trace;
+
+// Generates a random GUID to help us keep track of things across sessions
+// Credit: http://stackoverflow.com/a/8809472/816458
+function newGuid() {
+    var d = new Date().getTime();
+    var uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g,
+        function(c) {
+            var r = (d + Math.random() * 16) % 16 | 0;
+            d = Math.floor(d / 16);
+            return (c == 'x' ? r : (r & 0x3 | 0x8)).toString(16);
+        });
+    return uuid;
+}
+
+if (!Date.now) {
+    Date.now = function() { return new Date().getTime(); };
+}
+
+// Setup
+if (window.createLogger) {
+    Trace = window.createLogger();
+} else {
+    Trace = new Logger(50);
+}
+
+window.onerror = function(msg, url, line, column, error) {
+    Trace.logError({
+        'message': msg,
+        'fileName': url,
+        'lineNumber': line,
+        'columnNumber': column,
+        'stack': error ? error.stack : null,
+    });
+};

--- a/objects.js
+++ b/objects.js
@@ -1449,7 +1449,11 @@ SpriteMorph.prototype.appearIn = function (ide) {
 // SpriteMorph versioning
 
 SpriteMorph.prototype.setName = function (string) {
-    this.name = string || this.name;
+    var name = string || this.name;
+    if (name != this.name) {
+        Trace.log('Sprite.setName', name);
+    }
+    this.name = name;
     this.version = Date.now();
 };
 
@@ -2299,6 +2303,7 @@ SpriteMorph.prototype.freshPalette = function (category) {
             menu.addItem(
                 'show primitives',
                 function () {
+                    Trace.log('IDE.showPrimitives', ide.currentCategory);
                     var hiddens = StageMorph.prototype.hiddenPrimitives,
                         defs = SpriteMorph.prototype.blocks;
                     Object.keys(hiddens).forEach(function (sel) {
@@ -2813,6 +2818,7 @@ SpriteMorph.prototype.reporterize = function (expressionString) {
 // SpriteMorph variable management
 
 SpriteMorph.prototype.addVariable = function (name, isGlobal) {
+    Trace.log('Sprite.addVariable', name);
     var ide = this.parentThatIsA(IDE_Morph);
     if (isGlobal) {
         this.globalVariables().addVar(name);
@@ -2826,6 +2832,7 @@ SpriteMorph.prototype.addVariable = function (name, isGlobal) {
 };
 
 SpriteMorph.prototype.deleteVariable = function (varName) {
+    Trace.log('Sprite.deleteVariable', varName);
     var ide = this.parentThatIsA(IDE_Morph);
     if (!contains(this.inheritedVariableNames(true), varName)) {
         // check only shadowed variables
@@ -5342,6 +5349,7 @@ function StageMorph(globals) {
 
 StageMorph.prototype.init = function (globals) {
     this.name = localize('Stage');
+    this.guid = newGuid();
     this.threads = new ThreadManager();
     this.variables = new VariableFrame(globals || null, this);
     this.scripts = new ScriptsMorph(this);

--- a/snap.html
+++ b/snap.html
@@ -20,6 +20,10 @@
 		<script type="text/javascript" src="cloud.js"></script>
 		<script type="text/javascript" src="sha512.js"></script>
 		<script type="text/javascript" src="FileSaver.min.js"></script>
+		<script type="text/javascript" src="logging/config.js"></script>
+		<script type="text/javascript" src="logging/logger.js"></script>
+		<script type="text/javascript" src="logging/console-logger.js"></script>
+		<script type="text/javascript" src="logging/main.js"></script>
 		<script type="text/javascript">
 			var world;
 			window.onload = function () {


### PR DESCRIPTION
This pull request includes a basic version of the logging code from [iSnap](go.ncsu.edu/isnap). It includes a basic logger class that outputs to the console, logging calls throughout the codebase, and a few additions to the Snap! project data-structure.

To enable logging, simply copy the `logging/config.js.example` file to `logging/config.js`. Then you should see logging output in your console. 

This pull request is mainly intended as an offer to make the logging code official, and a request for feedback on how to make it suitable for the main Snap branch. I'm mainly expecting comments, but if it seems suitable as-is, feel free to merge it in and make your own changes.

Primary features include:
* An "abstract" `logger.js` class and a basic `console-logger.js` implementation that outputs to the console. The logger handles saving snapshots of the code with each log if the code has changed.
* Logging calls throughout the codebase.
* A `logging/config.js.example` file. When copied to `logging/config.js`, this file says what type of logger to use and can also be used to configure the snap cloud URL. If this file is missing or empty, the logger is not created, but no errors will occur.
* Blocks now have unique IDs that are saved/loaded with a project.
* The project XML now contains an <editing> section that includes open editors and their unsaved custom block code. When a project with <editing> block is loaded, these block editor dialogs will be opened as well.

Logs come as JSON objects with a few primary fields:
* `message`: A label for an event which occurred (e.g. "Block.snapped")
* `code`: An XML representation of the project after the event occurred (if changed), with the stage image removed.
* `time`: The time (as a timestamp) when the even occurred.
* `projectID`: A GUID for the project currently being edited
* `userInfo`: An object with info about the current user. It currently contains a `browserID` GUID which is stored as a cookie in the browser and a  `sessionID` GUID for the current browser session. In other settings, this can be augmented with a `userID` if users log in to use Snap!.