### PR TITLE
Use <input> for internal c&p text handling.

### DIFF
--- a/morphic.js
+++ b/morphic.js
@@ -5207,12 +5207,16 @@ CursorMorph.prototype.init = function (aStringOrTextMorph) {
 
 CursorMorph.prototype.initializeClipboardHandler = function () {
     // Add hidden text box for copying and pasting
+    // Use an <input> not a <textarea> to prevent autocaps from taking affect.
     var myself = this,
         wrrld = this.target.world();
 
-    this.clipboardHandler = document.createElement('textarea');
+    this.clipboardHandler = document.createElement('input');
     this.clipboardHandler.style.position = 'absolute';
     this.clipboardHandler.style.right = '101%'; // placed just out of view
+    this.clipboardHandler.autocomplete = "off";
+    this.clipboardHandler.autocorrect = "off";
+    this.clipboardHandler.autocapitalize = "off";
 
     document.body.appendChild(this.clipboardHandler);
 


### PR DESCRIPTION
The current version uses <textarea> which means that everything has
autocaps applied, which can make it really annoying to try to login.

There's a minor side effect: copying and pasting outside of Snap!
(on mac OS) doesn't keep any newlines. Newlines are still saved and
rendered OK. This is only a minor annoyance when copying JS code outside
of Snap!