### PR TITLE
Sound envelope addition/click reduction

### DIFF
--- a/objects.js
+++ b/objects.js
@@ -7582,7 +7582,9 @@ Note.prototype.setupContext = function () {
     }
     Note.prototype.audioContext = new AudioContext();
     Note.prototype.gainNode = Note.prototype.audioContext.createGain();
-    Note.prototype.gainNode.gain.value = 0.25; // reduce volume by 1/4
+    Note.prototype.volumeLevel = 0.25;
+    Note.prototype.attackTime = 0.075;
+    Note.prototype.releaseTime = 0.075;
 };
 
 // Note playing
@@ -7600,7 +7602,10 @@ Note.prototype.play = function () {
         Math.pow(2, (this.pitch - 69) / 12) * 440;
     this.oscillator.connect(this.gainNode);
     this.gainNode.connect(this.audioContext.destination);
+    this.gainNode.gain.value = 0;
+    this.gainNode.gain.linearRampToValueAtTime(this.volumeLevel, this.audioContext.currentTime + this.attackTime);
     this.oscillator.start(0);
+    this.released = false;
 };
 
 Note.prototype.stop = function () {
@@ -7609,6 +7614,13 @@ Note.prototype.stop = function () {
         this.oscillator = null;
     }
 };
+
+Note.prototype.release = function () {
+    if (!this.released) {
+        this.released = true;
+        this.gainNode.gain.linearRampToValueAtTime(0, this.audioContext.currentTime + this.releaseTime);
+    }
+}
 
 // CellMorph //////////////////////////////////////////////////////////
 

--- a/objects.js
+++ b/objects.js
@@ -7626,7 +7626,6 @@ Note.prototype.play = function (secs) {
     this.gainNode.gain.linearRampToValueAtTime(0, releaseEnd);
 
     this.oscillator.start(0);
-    this.released = false;
 };
 
 Note.prototype.stop = function () {

--- a/objects.js
+++ b/objects.js
@@ -7590,6 +7590,7 @@ Note.prototype.play = function (secs) {
     var attackStart, releaseStart, releaseEnd;
     var oscillator = this.audioContext.createOscillator();
     var gainNode = this.audioContext.createGain();
+    this.gainNode = gainNode;
 
     if (!oscillator.start) {
         oscillator.start = oscillator.noteOn;
@@ -7614,7 +7615,7 @@ Note.prototype.play = function (secs) {
     oscillator.start(0);
 
     // resource deallocation closure
-    var _this = this;
+    var releaseTime = this.releaseTime;
     var dealloc = function () {
         if (gainNode.gain.value == 0) {
             gainNode.disconnect();
@@ -7625,8 +7626,16 @@ Note.prototype.play = function (secs) {
             setTimeout(dealloc, 1000);
         }
     };
-    setTimeout(dealloc, (secs + (_this.releaseTime * 2)) * 1000);
+    setTimeout(dealloc, (secs + (releaseTime * 2)) * 1000);
 };
+
+Note.prototype.stop = function () {
+    var currentTime = this.gainNode.context.currentTime;
+    var releaseEnd = currentTime + this.releaseTime;
+    this.gainNode.gain.cancelScheduledValues(currentTime);
+    this.gainNode.gain.setValueAtTime(this.volumeLevel, currentTime);
+    this.gainNode.gain.linearRampToValueAtTime(0, releaseEnd);
+}
 
 // CellMorph //////////////////////////////////////////////////////////
 

--- a/threads.js
+++ b/threads.js
@@ -3293,7 +3293,6 @@ Process.prototype.doPlayNote = function (pitch, beats) {
 };
 
 Process.prototype.doPlayNoteForSecs = function (pitch, secs) {
-    // interpolated
     if (!this.context.startTime) {
         this.context.startTime = Date.now();
         this.context.activeNote = new Note(pitch);
@@ -3301,7 +3300,6 @@ Process.prototype.doPlayNoteForSecs = function (pitch, secs) {
     }
     if ((Date.now() - this.context.startTime) >= (secs * 1000)) {
         if (this.context.activeNote) {
-            this.context.activeNote.stop();
             this.context.activeNote = null;
         }
         return null;
@@ -3606,7 +3604,6 @@ Context.prototype.addInput = function (input) {
 
 Context.prototype.stopMusic = function () {
     if (this.activeNote) {
-        this.activeNote.stop();
         this.activeNote = null;
     }
 };

--- a/threads.js
+++ b/threads.js
@@ -3297,10 +3297,7 @@ Process.prototype.doPlayNoteForSecs = function (pitch, secs) {
     if (!this.context.startTime) {
         this.context.startTime = Date.now();
         this.context.activeNote = new Note(pitch);
-        this.context.activeNote.play();
-    }
-    if ((Date.now() - this.context.startTime) >= ((secs - this.context.activeNote.releaseTime) * 1000)) {
-        this.context.activeNote.release();
+        this.context.activeNote.play(secs);
     }
     if ((Date.now() - this.context.startTime) >= (secs * 1000)) {
         if (this.context.activeNote) {

--- a/threads.js
+++ b/threads.js
@@ -3604,6 +3604,7 @@ Context.prototype.addInput = function (input) {
 
 Context.prototype.stopMusic = function () {
     if (this.activeNote) {
+        this.activeNote.stop();
         this.activeNote = null;
     }
 };

--- a/threads.js
+++ b/threads.js
@@ -3299,6 +3299,9 @@ Process.prototype.doPlayNoteForSecs = function (pitch, secs) {
         this.context.activeNote = new Note(pitch);
         this.context.activeNote.play();
     }
+    if ((Date.now() - this.context.startTime) >= ((secs - this.context.activeNote.releaseTime) * 1000)) {
+        this.context.activeNote.release();
+    }
     if ((Date.now() - this.context.startTime) >= (secs * 1000)) {
         if (this.context.activeNote) {
             this.context.activeNote.stop();


### PR DESCRIPTION
I'm not sure it 100% eliminates clicking at note start/stop - listening very carefully, I believe I can still sometimes hear it... might be timing limitations in the browser implementation of the Web Audio API. I've also encountered some inconsistencies in how "clicky" very fast notes can sound (eighth notes, sixteenth notes, etc).

Still, seems to be a vast improvement on the current noisy clicking sounds found at the starts and, especially, stops, of played notes.

This is my first foray into the Web Audio API, and in particular I don't know the relative portability of various facilities in the Web Audio API. It might be well to add some safety checks, or wrap things in try-blocks, and fall back to hard-setting the gain value as before.