### PR TITLE
Copy project URL to clipboard on share

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -6295,11 +6295,19 @@ ProjectDialogMorph.prototype.shareProject = function () {
             'Share Project',
             function () {
                 myself.ide.showMessage('sharing\nproject...');
+
+                var hash = 'present:Username=' +
+                    encodeURIComponent(SnapCloud.username.toLowerCase()) +
+                    '&ProjectName=' +
+                    encodeURIComponent(proj.ProjectName);
+
                 SnapCloud.reconnect(
                     function () {
                         SnapCloud.callService(
                             'publishProject',
                             function () {
+                                var isCopied = false;
+
                                 SnapCloud.disconnect();
                                 proj.Public = 'true';
                                 myself.unshareButton.show();
@@ -6309,19 +6317,27 @@ ProjectDialogMorph.prototype.shareProject = function () {
                                 entry.label.changed();
                                 myself.buttons.fixLayout();
                                 myself.drawNew();
-                                myself.ide.showMessage('shared.', 2);
+
+                                try {
+                                    var clipboard = document.getElementById('clipboard');
+                                    var location = window.location;
+
+                                    clipboard.value = location.protocol + '//' + location.hostname + location.pathname + '#' + hash;
+                                    clipboard.focus();
+                                    clipboard.setSelectionRange(0, clipboard.value.length);
+
+                                    isCopied = document.execCommand('copy');
+                                } catch (e) {}
+
+                                myself.ide.showMessage('shared' + (isCopied ? ' and copied' : '') + '.', 2);
                             },
                             myself.ide.cloudError(),
                             [proj.ProjectName]
                         );
+
                         // Set the Shared URL if the project is currently open
                         if (proj.ProjectName === ide.projectName) {
-                            var usr = SnapCloud.username,
-                                projectId = 'Username=' +
-                                    encodeURIComponent(usr.toLowerCase()) +
-                                    '&ProjectName=' +
-                                    encodeURIComponent(proj.ProjectName);
-                            location.hash = 'present:' + projectId;
+                            location.hash = hash;
                         }
                     },
                     myself.ide.cloudError()

--- a/snap.html
+++ b/snap.html
@@ -36,6 +36,7 @@
 		</script>
 	</head>
 	<body style="margin: 0;">
-		<canvas id="world" tabindex="1" style="position: absolute;" />
+		<canvas id="world" tabindex="1" style="position: absolute;"></canvas>
+		<input id="clipboard" type="text">
 	</body>
 </html>


### PR DESCRIPTION
This at least works in Chrome, but I was not able to test this end-to-end locally due to whitelisted server origins. I'm also up for suggestions on how to better target the `<input>` element.