### PR TITLE
Suggestion to allow Snap menus customization for Snap! extensions

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -562,7 +562,8 @@ IDE_Morph.prototype.createLogo = function () {
     };
 
     this.logo.mouseClickLeft = function () {
-        myself.snapMenu();
+        var menu = myself.snapMenu();
+        menu.popup(myself.world(), myself.logo.bottomLeft());
     };
 
     this.logo.color = new Color();
@@ -813,7 +814,10 @@ IDE_Morph.prototype.createControlBar = function () {
     // projectButton
     button = new PushButtonMorph(
         this,
-        'projectMenu',
+        function () {
+            var menu = myself.projectMenu()
+            menu.popup(myself.world(), myself.controlBar.projectButton.bottomLeft());
+        },
         new SymbolMorph('file', 14)
         //'\u270E'
     );
@@ -837,7 +841,10 @@ IDE_Morph.prototype.createControlBar = function () {
     // settingsButton
     button = new PushButtonMorph(
         this,
-        'settingsMenu',
+        function () {
+            var menu = myself.settingsMenu()
+            menu.popup(myself.world(), myself.controlBar.settingsButton.bottomLeft());
+        },
         new SymbolMorph('gears', 14)
         //'\u2699'
     );
@@ -861,7 +868,10 @@ IDE_Morph.prototype.createControlBar = function () {
     // cloudButton
     button = new PushButtonMorph(
         this,
-        'cloudMenu',
+        function () {
+            var menu = myself.cloudMenu()
+            menu.popup(myself.world(), myself.controlBar.cloudButton.bottomLeft());
+        },
         new SymbolMorph('cloud', 11)
     );
     button.corner = 12;
@@ -2424,14 +2434,15 @@ IDE_Morph.prototype.snapMenu = function () {
             new Color(100, 0, 0)
         );
     }
-    menu.popup(world, this.logo.bottomLeft());
+
+    return menu;
+
 };
 
 IDE_Morph.prototype.cloudMenu = function () {
     var menu,
         myself = this,
         world = this.world(),
-        pos = this.controlBar.cloudButton.bottomLeft(),
         shiftClicked = (world.currentKey === 16);
 
     menu = new MenuMorph(this);
@@ -2560,7 +2571,9 @@ IDE_Morph.prototype.cloudMenu = function () {
             new Color(100, 0, 0)
         );
     }
-    menu.popup(world, pos);
+
+    return menu;
+
 };
 
 IDE_Morph.prototype.settingsMenu = function () {
@@ -2568,7 +2581,6 @@ IDE_Morph.prototype.settingsMenu = function () {
         stage = this.stage,
         world = this.world(),
         myself = this,
-        pos = this.controlBar.settingsButton.bottomLeft(),
         shiftClicked = (world.currentKey === 16);
 
     function addPreference(label, toggle, test, onHint, offHint, hide) {
@@ -2972,14 +2984,15 @@ IDE_Morph.prototype.settingsMenu = function () {
         'check to enable\nsaving linked sublist identities',
         true
     );
-    menu.popup(world, pos);
+
+    return menu;
+
 };
 
 IDE_Morph.prototype.projectMenu = function () {
     var menu,
         myself = this,
         world = this.world(),
-        pos = this.controlBar.projectButton.bottomLeft(),
         graphicsName = this.currentSprite instanceof SpriteMorph ?
                 'Costumes' : 'Backgrounds',
         shiftClicked = (world.currentKey === 16);
@@ -3143,7 +3156,8 @@ IDE_Morph.prototype.projectMenu = function () {
         'Select a sound from the media library'
     );
 
-    menu.popup(world, pos);
+    return menu;
+
 };
 
 IDE_Morph.prototype.resourceURL = function () {


### PR DESCRIPTION
Snap menu functions are building and painting their menus at the same time.

This PR is only spliting building and painting (adding a _return_ of the menu before painting) to allow customization of these menus into Snap! extensions.

For example, Snap4Arduino has extra-options. This PR will allow to remove an ugly hack.

Thanks,
Joan