### PR TITLE
Use raw image src if costume image not loaded

### DIFF
--- a/store.js
+++ b/store.js
@@ -1342,6 +1342,7 @@ SnapSerializer.prototype.loadValue = function (model) {
                 v = new SVG_Costume(null, name, center);
                 image.onload = function () {
                     v.contents = image;
+                    v.imageSrc = null;
                     v.version = +new Date();
                     if (typeof v.loaded === 'function') {
                         v.loaded();
@@ -1359,6 +1360,7 @@ SnapSerializer.prototype.loadValue = function (model) {
                         context = canvas.getContext('2d');
                     context.drawImage(image, 0, 0);
                     v.contents = canvas;
+                    v.imageSrc = null;
                     v.version = +new Date();
                     if (typeof v.loaded === 'function') {
                         v.loaded();
@@ -1368,6 +1370,7 @@ SnapSerializer.prototype.loadValue = function (model) {
                 };
             }
             image.src = model.attributes.image;
+            v.imageSrc = model.attributes.image;
         }
         record();
         return v;
@@ -1614,13 +1617,20 @@ SpriteMorph.prototype.toXML = function (serializer) {
 Costume.prototype[XML_Serializer.prototype.mediaDetectionProperty] = true;
 
 Costume.prototype.toXML = function (serializer) {
+    // if serializing before the image is loaded, use the raw source. Otherwise,
+    // we will serialize as normal
+    var imageData = this.imageSrc;
+    if (!imageData) {
+        imageData = this instanceof SVG_Costume ? this.contents.src
+            : normalizeCanvas(this.contents).toDataURL('image/png');
+    }
+
     return serializer.format(
         '<costume name="@" center-x="@" center-y="@" image="@" ~/>',
         this.name,
         this.rotationCenter.x,
         this.rotationCenter.y,
-        this instanceof SVG_Costume ?
-                this.contents.src : this.contents.toDataURL('image/png')
+        imageData
     );
 };
 


### PR DESCRIPTION
This is a pretty minor async bug. If a costume is serialized before the image data is loaded, it will basically clear itself (because the current image data is nothing).

Not a very pressing issue but I thought I would make a PR in case you were interested!