### PR TITLE
Minor enhancement for keeping the appMode while opening a project

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -1041,6 +1041,7 @@ IDE_Morph.prototype.createPalette = function (forSearching) {
 
     this.palette.setWidth(this.logo.width());
     this.add(this.palette);
+    if (this.isAppMode) this.palette.hide();
     return this.palette;
 };
 
@@ -1049,6 +1050,7 @@ IDE_Morph.prototype.createPaletteHandle = function () {
     if (this.paletteHandle) {this.paletteHandle.destroy(); }
     this.paletteHandle = new PaletteHandleMorph(this.categories);
     this.add(this.paletteHandle);
+    if (this.isAppMode) this.paletteHandle.hide();
 };
 
 IDE_Morph.prototype.createStage = function () {
@@ -1297,6 +1299,7 @@ IDE_Morph.prototype.createSpriteBar = function () {
         this.tabBar.setLeft(this.left());
         this.tabBar.setBottom(this.bottom());
     };
+    if (this.isAppMode) this.spriteBar.hide();
 };
 
 IDE_Morph.prototype.createSpriteEditor = function () {
@@ -1537,6 +1540,7 @@ IDE_Morph.prototype.createCorral = function () {
         myself.createCorral();
         myself.fixLayout();
     };
+    if (this.isAppMode) this.corral.hide();
 };
 
 // IDE_Morph layout


### PR DESCRIPTION
`openProject` call doesn't take into account whether currently the UI is in appMode (fullscreen stage) or not and thus it displays a few elements despite being in appMode.
![ss](https://i.imgur.com/89R2yrg.png) 