### PR TITLE
Convert unsupported categories to 'custom'. Fixes #1994

### DIFF
--- a/store.js
+++ b/store.js
@@ -805,7 +805,8 @@ SnapSerializer.prototype.loadCustomBlocks = function (
             child.attributes.s || '',
             object
         );
-        definition.category = child.attributes.category || 'other';
+        definition.category = SpriteMorph.prototype.categories.indexOf(child.attributes.category) !== -1 ?
+            child.attributes.category : 'other';
         definition.type = child.attributes.type || 'command';
         definition.isGlobal = (isGlobal === true);
         if (definition.isGlobal) {


### PR DESCRIPTION
I added checking if the block category is supported in the current environment; unsupported categories will be converted to "custom" on import.