### PR TITLE
make reportAnd/Or work with non-strict booleans. fixes #2058

### DIFF
--- a/threads.js
+++ b/threads.js
@@ -876,7 +876,7 @@ Process.prototype.reportOr = function (block) {
         this.evaluateNextInput(block);
     } else {
         if (this.flashContext()) {return; }
-        this.returnValueToParentContext(inputs[1] === true);
+        this.returnValueToParentContext(!!inputs[1]);
         this.popContext();
     }
 };
@@ -894,7 +894,7 @@ Process.prototype.reportAnd = function (block) {
         this.evaluateNextInput(block);
     } else {
         if (this.flashContext()) {return; }
-        this.returnValueToParentContext(inputs[1] === true);
+        this.returnValueToParentContext(!!inputs[1]);
         this.popContext();
     }
 };


### PR DESCRIPTION
In #2058 @DavidGasku reported a weird behavior of the AND/OR block.

This happens because those blocks compute their value by evaluating its first argument as truthy and the 2nd one as an strict true boolean.

This PR makes the 2nd parameter to be evaluated in the same fashion as the 1st does.