### PR TITLE
Some Speedups to Importing Blocks

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -4358,7 +4358,7 @@ IDE_Morph.prototype.rawOpenBlocksString = function (str, name, silently) {
         blocks.forEach(function (def) {
             def.receiver = myself.stage;
             myself.stage.globalBlocks.push(def);
-            myself.stage.replaceDoubleDefinitionsFor(def);
+            myself.stage.replaceDoubleDefinitionsFor(def, silently);
         });
         this.flushPaletteCache();
         this.refreshPalette();
@@ -7315,7 +7315,7 @@ LibraryImportDialogMorph.prototype.importLibrary = function () {
         blocks.forEach(function (def) {
             def.receiver = ide.stage;
             ide.stage.globalBlocks.push(def);
-            ide.stage.replaceDoubleDefinitionsFor(def);
+            ide.stage.replaceDoubleDefinitionsFor(def, true);
         });
         ide.showMessage(localize('Imported') + ' ' + localize(libraryName), 2);
     } else {

--- a/objects.js
+++ b/objects.js
@@ -2378,7 +2378,7 @@ SpriteMorph.prototype.freshPalette = function (category) {
     palette.growth = new Point(0, MorphicPreferences.scrollBarSize);
 
     // toolbar:
-    
+
     palette.toolBar = new AlignmentMorph('column');
 
     searchButton = new PushButtonMorph(
@@ -5389,7 +5389,7 @@ SpriteMorph.prototype.doubleDefinitionsFor = function (definition) {
     });
 };
 
-SpriteMorph.prototype.replaceDoubleDefinitionsFor = function (definition) {
+SpriteMorph.prototype.replaceDoubleDefinitionsFor = function (definition, silently) {
     var doubles = this.doubleDefinitionsFor(definition),
         myself = this,
         stage,
@@ -5410,6 +5410,7 @@ SpriteMorph.prototype.replaceDoubleDefinitionsFor = function (definition) {
             return !contains(doubles, def);
         });
     }
+    if (silently) {return; }
     ide = this.parentThatIsA(IDE_Morph);
     if (ide) {
         ide.flushPaletteCache();


### PR DESCRIPTION
Eliminates a bunch of redraws which checking for duplicate blocks.

I really hate adding `silently` as a control parameter, but it seems like the common thing to do?