### PR TITLE
Automatically Update Snap! mirrors and web versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,10 @@
 language: generic
 # We don't actually have tests to run...
 script: exit 0;
-# Creating a release creates a "branch".
+# We need sshpass to sync to berkeley. (for now.)
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install sshpass
 jobs:
   include:
     - stage: deploy
@@ -22,20 +25,29 @@ jobs:
             all_branches: true
         # deploy to the Snap!Cloud repo
         # - provider: script
-        #   script: bash scripts/deploy.sh staging
+        #   script: |
+        #      git clone --depth=1 --recursive https://github.com/bromagosa/snapCloud
+        #      cd snapCloud/snap
+        #      git fetch origin --tags
+        #      release=$(git describe --tags `git rev-list --tags --max-count=1`)
+        #      git checkout $release
+        #      cd ..; git commit -m "[ci]: automatically checkout ${release}"
+        #      git push origin master
         #   on:
         #     repo: jmoenig/Snap--Build-Your-Own-Blocks
         #     condition: $TRAVIS_TAG =~ ^v[0-9]+
-        # deploy master to snap.berkeley.edu/snapsource/development
-        # - provider: script
-        #   script: scp -r ./* michael@abbenay.cs.berkeley.edu:~/dev/
-        #   on:
-        #     branch: master
-        # deploy a release to berkeley...
-        # - provider: script
-        #   script: scp -r ./* michael@abbenay.cs.berkeley.edu:~/dev/
-        #   on:
-        #     repo: cycomachead/snap
-        #     repo: jmoenig/Snap--Build-Your-Own-Blocks
-        #   condition: $TRAVIS_TAG =~ ^[0-9]+\.[0-9]+
-        #   all_branches: true
+        #     all_branches: true
+        # deploy master to snap.berkeley.edu/snapsource/dev
+        - provider: script
+          script: sshpass -p "${REMOTE_PASSWORD}" rsync -avz cycomachead/snap/ ${ACCOUNT}:~/snapsource/
+          on:
+            repo: cycomachead/snap
+            # repo: jmoenig/Snap--Build-Your-Own-Blocks
+            branch: master
+        # deploy a release to main snap URL
+        - provider: script
+          script: sshpass -p "${REMOTE_PASSWORD}" rsync -avz cycomachead/snap/ ${ACCOUNT}:~/snapsource/
+          on:
+            repo: jmoenig/Snap--Build-Your-Own-Blocks
+          condition: $TRAVIS_TAG =~ ^[0-9]+\.[0-9]+
+          all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+# Deploy Snap! when a release is created.
+
+# Creating a release creates a "branch".
+deploy:
+  # This deploys to cs10.org/snap/
+  - provider: pages
+    skip-cleanup: true
+    github-token: $GITHUB_TOKEN
+    keep-history: false
+    repo: cs10/snap
+    target-branch: master
+    on:
+      repo: jmoenig/Snap--Build-Your-Own-Blocks
+      condition: $TRAVIS_BRANCH =~ ^v[0-9]+
+  # deploy to the Snap!Cloud repo
+  # - provider: script
+  #   script: bash scripts/deploy.sh staging
+  #   on:
+  #     repo: jmoenig/Snap--Build-Your-Own-Blocks
+  #     condition: $TRAVIS_BRANCH =~ ^v[0-9]+
+  # deploy master to snap.berkeley.edu/snapsource/development
+  # - provider: script
+  #   script: bash scripts/deploy.sh staging
+  #   on:
+  #     branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ jobs:
           repo: cs10/snap
           target-branch: master
           on:
-            repo: jmoenig/Snap--Build-Your-Own-Blocks
+            repo: cycomachead/snap
+            # repo: jmoenig/Snap--Build-Your-Own-Blocks
             condition: $TRAVIS_TAG =~ ^[0-9]+
         # deploy to the Snap!Cloud repo
         # - provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,11 @@ jobs:
           on:
             repo: cycomachead/snap
             # repo: jmoenig/Snap--Build-Your-Own-Blocks
-            branches:
-              only:
-                - /^[0-9]+\.[0-9]+/
+            # branches:
+            #   only:
+            #     - /^[0-9]+\.[0-9]+/
             condition: $TRAVIS_TAG =~ ^[0-9]+\.[0-9]+
+            all_branches: true
         # deploy to the Snap!Cloud repo
         # - provider: script
         #   script: bash scripts/deploy.sh staging

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ jobs:
           on:
             repo: cycomachead/snap
             # repo: jmoenig/Snap--Build-Your-Own-Blocks
-            condition: $TRAVIS_TAG =~ ^[0-9]+
+            branch: /^[0-9]+\.[0-9]+/
+            condition: $TRAVIS_TAG =~ ^[0-9]+\.[0-9]+
         # deploy to the Snap!Cloud repo
         # - provider: script
         #   script: bash scripts/deploy.sh staging

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,7 @@ jobs:
           repo: cs10/snap
           target-branch: master
           on:
-            repo: cycomachead/snap
-            # repo: jmoenig/Snap--Build-Your-Own-Blocks
+            repo: jmoenig/Snap--Build-Your-Own-Blocks
             condition: $TRAVIS_TAG =~ ^[0-9]+\.[0-9]+
             all_branches: true
         # deploy to the Snap!Cloud repo
@@ -41,8 +40,7 @@ jobs:
         - provider: script
           script: sshpass -p "${REMOTE_PASSWORD}" rsync -avz cycomachead/snap/ ${ACCOUNT}:~/snapsource/
           on:
-            repo: cycomachead/snap
-            # repo: jmoenig/Snap--Build-Your-Own-Blocks
+            repo: jmoenig/Snap--Build-Your-Own-Blocks
             branch: master
         # deploy a release to main snap URL
         - provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,9 @@ jobs:
           on:
             repo: cycomachead/snap
             # repo: jmoenig/Snap--Build-Your-Own-Blocks
-            branch: /^[0-9]+\.[0-9]+/
+            branches:
+              only:
+                - /^[0-9]+\.[0-9]+/
             condition: $TRAVIS_TAG =~ ^[0-9]+\.[0-9]+
         # deploy to the Snap!Cloud repo
         # - provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,32 @@
 # This uses travis-ci.org to automate releasing Snap!
-lang: node_js
+language: generic
 # We don't actually have tests to run...
 script: exit 0;
 # Creating a release creates a "branch".
-deploy:
-  # This deploys to cs10.org/snap/
-  - provider: pages
-    skip-cleanup: true
-    github-token: $GITHUB_TOKEN
-    keep-history: false
-    repo: cs10/snap
-    target-branch: master
-    on:
-      repo: jmoenig/Snap--Build-Your-Own-Blocks
-      condition: $TRAVIS_TAG =~ ^v[0-9]+
-  # deploy to the Snap!Cloud repo
-  # - provider: script
-  #   script: bash scripts/deploy.sh staging
-  #   on:
-  #     repo: jmoenig/Snap--Build-Your-Own-Blocks
-  #     condition: $TRAVIS_BRANCH =~ ^v[0-9]+
-  # deploy master to snap.berkeley.edu/snapsource/development
-  # - provider: script
-  #   script: bash scripts/deploy.sh staging
-  #   on:
-  #     branch: master
-  # deploy a release to berkeley...
+jobs:
+  include:
+    - stage: deploy
+      script: skip
+      deploy:
+        # This deploys to cs10.org/snap/
+        - provider: pages
+          skip-cleanup: true
+          github-token: $GITHUB_TOKEN
+          keep-history: false
+          repo: cs10/snap
+          target-branch: master
+          on:
+            repo: jmoenig/Snap--Build-Your-Own-Blocks
+            condition: $TRAVIS_TAG =~ ^[0-9]+
+        # deploy to the Snap!Cloud repo
+        # - provider: script
+        #   script: bash scripts/deploy.sh staging
+        #   on:
+        #     repo: jmoenig/Snap--Build-Your-Own-Blocks
+        #     condition: $TRAVIS_TAG =~ ^v[0-9]+
+        # deploy master to snap.berkeley.edu/snapsource/development
+        # - provider: script
+        #   script: bash scripts/deploy.sh staging
+        #   on:
+        #     branch: master
+        # deploy a release to berkeley...

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,12 @@ jobs:
         - provider: pages
           skip-cleanup: true
           github-token: $GITHUB_TOKEN
-          keep-history: false
+          keep-history: true
           repo: cs10/snap
           target-branch: master
           on:
             repo: cycomachead/snap
             # repo: jmoenig/Snap--Build-Your-Own-Blocks
-            # branches:
-            #   only:
-            #     - /^[0-9]+\.[0-9]+/
             condition: $TRAVIS_TAG =~ ^[0-9]+\.[0-9]+
             all_branches: true
         # deploy to the Snap!Cloud repo
@@ -31,7 +28,14 @@ jobs:
         #     condition: $TRAVIS_TAG =~ ^v[0-9]+
         # deploy master to snap.berkeley.edu/snapsource/development
         # - provider: script
-        #   script: bash scripts/deploy.sh staging
+        #   script: scp -r ./* michael@abbenay.cs.berkeley.edu:~/dev/
         #   on:
         #     branch: master
         # deploy a release to berkeley...
+        # - provider: script
+        #   script: scp -r ./* michael@abbenay.cs.berkeley.edu:~/dev/
+        #   on:
+        #     repo: cycomachead/snap
+        #     repo: jmoenig/Snap--Build-Your-Own-Blocks
+        #   condition: $TRAVIS_TAG =~ ^[0-9]+\.[0-9]+
+        #   all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
-# Deploy Snap! when a release is created.
-
+# This uses travis-ci.org to automate releasing Snap!
+lang: node_js
+# We don't actually have tests to run...
+script: exit 0;
 # Creating a release creates a "branch".
 deploy:
   # This deploys to cs10.org/snap/
@@ -11,7 +13,7 @@ deploy:
     target-branch: master
     on:
       repo: jmoenig/Snap--Build-Your-Own-Blocks
-      condition: $TRAVIS_BRANCH =~ ^v[0-9]+
+      condition: $TRAVIS_TAG =~ ^v[0-9]+
   # deploy to the Snap!Cloud repo
   # - provider: script
   #   script: bash scripts/deploy.sh staging
@@ -23,3 +25,4 @@ deploy:
   #   script: bash scripts/deploy.sh staging
   #   on:
   #     branch: master
+  # deploy a release to berkeley...


### PR DESCRIPTION
This uses the free travis-ci.com service to automatically update
Snap<em>!</em> when a new release is published. When new versions are
pushed to `master` it will update the dev URL on the website.

This will require Jens enabling builds for Snap<em>!</em> on travis-ci.com