### PR TITLE
fix: can't play sounds by name if name is a number

### DIFF
--- a/src/objects.js
+++ b/src/objects.js
@@ -3196,7 +3196,7 @@ SpriteMorph.prototype.playSound = function (name) {
     var stage = this.parentThatIsA(StageMorph),
         sound = name instanceof Sound ? name : detect(
             this.sounds.asArray(),
-            function (s) {return s.name === name; }
+            function (s) {return s.name === name.toString(); }
         ),
         active;
     if (sound) {


### PR DESCRIPTION
This used not to work:

![imatge](https://user-images.githubusercontent.com/1016697/49795400-2e35ac00-fd3a-11e8-97ed-250cc7b90dab.png)
![number sound test script pic](https://user-images.githubusercontent.com/1016697/49795365-152cfb00-fd3a-11e8-9735-28ce1f122dbb.png)

This PR fixes it :)