### PR TITLE
Use browser's textarea to support input from IME

### DIFF
--- a/snap.html
+++ b/snap.html
@@ -5,8 +5,10 @@
         <title>Snap! Build Your Own Blocks 5 - Beta -</title>
         <link rel="shortcut icon" href="src/favicon.ico">
         <script type="text/javascript" src="src/morphic.js?version=2019-01-10"></script>
+        <script type="text/javascript" src="src/imeChangesToMorphic.js"></script>
         <script type="text/javascript" src="src/widgets.js?version=2018-10-02"></script>
-        <script type="text/javascript" src="src/blocks.js?version=2019-02-06"></script>
+        <script type="text/javascript" src="src/blocks.js?version=2019-01-28"></script>
+        <script type="text/javascript" src="src/imeChangesToBlocks.js"></script>
         <script type="text/javascript" src="src/threads.js?version=2019-01-28"></script>
         <script type="text/javascript" src="src/objects.js?version=2019-01-28"></script>
         <script type="text/javascript" src="src/gui.js?version=2019-01-28"></script>

--- a/src/imeChangesToBlocks.js
+++ b/src/imeChangesToBlocks.js
@@ -1,5 +1,5 @@
 /**
- * Changes made in this file related to a bug that "shift-click" does not
+ * Changes made in this file related to a bug that "shift+click" does not
  * select text as expected.
  *
  * This reason for the bug is that in the previous version of the following

--- a/src/imeChangesToBlocks.js
+++ b/src/imeChangesToBlocks.js
@@ -1,0 +1,34 @@
+/**
+ * Changes made in this file related to a bug that "shift-click" does not
+ * select text as expected.
+ *
+ * This reason for the bug is that in the previous version of the following
+ * function, stopEditing() is always called after a mousedown event, then a
+ * new editing session started, and lost the selection status. The change I
+ * made is only to start a new editor if the target is not being edit now.
+ *
+ * I think the stopEditing() call should be made in WorldMorph.edit, if
+ * needed, since WorldMorph holds information to make the decision.
+ * WorldMorph.edit should check that:
+ * 1. If the target morph is being editing now, then do nothing.
+ * 2. If it is editing other morph, stop it.
+ * 3. Start a new editing session.
+ *
+ */
+InputSlotMorph.prototype.mouseDownLeft = function (pos) {
+    var world;
+    if (this.isReadOnly || this.arrow().bounds.containsPoint(pos)) {
+        this.escalateEvent('mouseDownLeft', pos);
+    } else {
+        world = this.world();
+        var editTarget = this.selectForEdit().contents();
+        var already = world && world.cursor.target === editTarget;
+
+        if (!already) {
+            if (world) {
+                world.stopEditing();
+            }
+            this.selectForEdit().contents().edit();
+        }
+    }
+};

--- a/src/imeChangesToMorphic.js
+++ b/src/imeChangesToMorphic.js
@@ -4,7 +4,7 @@
  * IME.
  *
  * The design is as follows:
- * - The textarea handles all keyboard events: nevagition, control and
+ * - The textarea handles all keyboard events: navigation, control and
  *   character insertion.
  *
  * - After each keydown event, the content and selection status is copied to
@@ -15,26 +15,26 @@
  * - After each mouse events, the selection status, the position of cursor are
  *   copied to the textarea.
  *
- * Behavior differences caused by these changes:
+ * Improvements made by this change:
  * - The main goal:
  *   * Allow user to input texts in languages that needs an input method.
- * - Bugs fixed:
- *   * Shift-click does not select as expected
+ * - As side effects, two bugs are fixed:
+ *   * Shift+click does not select text as expected
  *   * Numeric input slots accept invalid inputs like "10-2" (but treat it as
  *     10, which is the returned value by parseFloat, I guess), "10.0.2"
  *
  * - Behavior change that might affect other part of system:
  *   * WorldMorph.edit: I added a guard at the start of the function, so that
- *     a new cursor morph is created only if the target morph is not the
- *     current editing morph. This is related to the above mentioned
- *     "shift-click" bug, which is caused by creating a new cursor morph for
- *     the current editing target.
+ *     a new cursor morph is created only if the target morph is different
+ *     from the one that is currently being edited. This is related to the
+ *     above mentioned "shift-click" bug, which is caused by creating a new
+ *     cursor morph for the current editing target.
  *
- * - Not ported features becuase I don't know the use cases
+ * - Not ported features
  *   * In the handling of ctrl(cmd)-keys, some special combinations are
- *     supported, for example ctrl + (keycode 123) will insert '{'. Is there
+ *     supported, for example ctrl + F12 (keycode 123) will insert '{'. Is there
  *     any device that needs these combinations? If needed, I think they can
- *     be ported.
+ *     be ported using synthetic events.
  */
 CursorMorph.prototype.init = function (aStringOrTextMorph) {
     var ls;

--- a/src/imeChangesToMorphic.js
+++ b/src/imeChangesToMorphic.js
@@ -1,0 +1,364 @@
+/**
+ * The changes in this file is to add a hidden textarea as the editing engine
+ * for text editing, so that Snap can make use of the browser's support for
+ * IME.
+ *
+ * The design is as follows:
+ * - The textarea handles all keyboard events: nevagition, control and
+ *   character insertion.
+ *
+ * - After each keydown event, the content and selection status is copied to
+ *   the target morph, and the caret position is copied to the cursor morph.
+ *
+ * - The target morph handles the mouse events
+ *
+ * - After each mouse events, the selection status, the position of cursor are
+ *   copied to the textarea.
+ *
+ * Behavior differences caused by these changes:
+ * - The main goal:
+ *   * Allow user to input texts in languages that needs an input method.
+ * - Bugs fixed:
+ *   * Shift-click does not select as expected
+ *   * Numeric input slots accept invalid inputs like "10-2" (but treat it as
+ *     10, which is the returned value by parseFloat, I guess), "10.0.2"
+ *
+ * - Behavior change that might affect other part of system:
+ *   * WorldMorph.edit: I added a guard at the start of the function, so that
+ *     a new cursor morph is created only if the target morph is not the
+ *     current editing morph. This is related to the above mentioned
+ *     "shift-click" bug, which is caused by creating a new cursor morph for
+ *     the current editing target.
+ *
+ * - Not ported features becuase I don't know the use cases
+ *   * In the handling of ctrl(cmd)-keys, some special combinations are
+ *     supported, for example ctrl + (keycode 123) will insert '{'. Is there
+ *     any device that needs these combinations? If needed, I think they can
+ *     be ported.
+ */
+CursorMorph.prototype.init = function (aStringOrTextMorph) {
+    var ls;
+
+    // additional properties:
+    this.keyDownEventUsed = false;
+    this.target = aStringOrTextMorph;
+    this.originalContents = this.target.text;
+    this.originalAlignment = this.target.alignment;
+    this.slot = this.target.text.length;
+    CursorMorph.uber.init.call(this);
+    ls = fontHeight(this.target.fontSize);
+    this.setExtent(new Point(Math.max(Math.floor(ls / 20), 1), ls));
+    this.drawNew();
+    this.image.getContext('2d').font = this.target.font();
+    if (this.target instanceof TextMorph &&
+            (this.target.alignment !== 'left')) {
+        this.target.setAlignmentToLeft();
+    }
+    this.gotoSlot(this.slot);
+
+    this.textarea = document.createElement('textarea');
+    this.textarea.style.zIndex = -1;
+    document.body.appendChild(this.textarea);
+    this.initializeTextarea(this.target.fontSize);
+};
+
+CursorMorph.prototype.initializeTextarea = function (fontSize) {
+    var myself = this;
+    this.textarea.style.position = 'absolute';
+    this.textarea.wrap = "off";
+    this.textarea.style.overflow = "hidden";
+    this.textarea.style.fontSize = fontSize + 'px';
+    this.textarea.autofocus = true;
+    this.textarea.value = this.target.text;
+    this.updateTextAreaPosition();
+    /* The following keyboard events has special meaning in Snap, so we must
+    handler them before the textarea:
+
+    - tab: goto next text field
+    - enter / shift+enter: accept the editing
+    - esc: discard the editing
+    - ctrl-d, ctrl-i and ctrl-p: doit, inspect it and print it
+
+    We also take the chance to filter out invalid inputs for numeric fields.
+    */
+    this.textarea.addEventListener('keydown', function (event) {
+        // The following line is copied from the "keydown" event handler of
+        // canvas (world). There are other actions in that handler, but since
+        // we are in between of editing, we don't need to do the other
+        // actions. We need this one to allow shift+click works.
+        myself.world().currentKey = event.keyCode;
+
+        var keyName = event.key;
+        var isValidInput = (
+            // non-numeric morph can accept any input
+            !myself.target.isNumeric  ||
+            // control keys
+            keyName.length > 1      ||
+            // digits, is it safe to use '0' <= keyName <= '9'?
+            !Number.isNaN(parseFloat(keyName)) ||
+            // at most one '.'
+            (keyName === '.' && myself.textarea.value.indexOf('.')===-1) ||
+            // or '-' as first char
+            (keyName === '-' && myself.textarea.selectionStart === 0)
+        );
+
+        // Make sure tab prevents default
+        if (keyName === 'U+0009' || keyName === 'Tab') {
+            event.preventDefault();
+            myself.target.escalateEvent('reactToEdit', myself.target);
+            if (event.shiftKey) {
+                myself.target.backTab(myself.target);
+            }
+            myself.target.tab(myself.target);
+        } else if (!isNil(myself.target.receiver) &&
+                    (event.ctrlKey || event.metaKey)) {
+            if (keyName === 'd') {
+                myself.target.doIt();
+            } else if (keyName === 'i') {
+                myself.target.inspectIt();
+            } else if (keyName === 'p') {
+                myself.target.showIt();
+            }
+            event.preventDefault();
+        } else if (isValidInput) {
+            switch (event.keyCode) {
+                case 13:
+                    if ((myself.target instanceof StringMorph) || shift) {
+                        myself.accept();
+                    }
+                    break;
+                case 27:
+                    myself.cancel();
+                    break;
+                default:
+                    nop();
+            }
+            myself.target.escalateEvent('reactToKeystroke', event);
+        } else {
+            event.preventDefault();
+        }
+    });
+
+    /* All other key events are handled by the textarea. Only after that, we
+       update the state of target morph and cursor morph.
+       - target morph: copy the content and selection status to the target.
+       - cursor morph: copy the caret position to cursor morph.
+     */
+    this.textarea.addEventListener('keyup', function (event) {
+        myself.world().currentKey = null;
+
+        var target = myself.target;
+        var textarea = myself.textarea;
+
+        target.text = textarea.value;
+        if (textarea.selectionStart === textarea.selectionEnd) {
+            target.startMark = null;
+            target.endMark = null;
+        } else {
+            if (textarea.selectionDirection === 'backward') {
+                target.startMark = textarea.selectionEnd;
+                target.endMark = textarea.selectionStart;
+            } else {
+                target.startMark = textarea.selectionStart;
+                target.endMark = textarea.selectionEnd;
+            }
+        }
+        target.changed();
+        target.drawNew();
+        target.changed();
+
+        myself.gotoSlot(textarea.selectionStart);
+
+        myself.updateTextAreaPosition();
+        target.escalateEvent('reactToKeystroke', event);
+    });
+};
+
+CursorMorph.prototype.updateTextAreaPosition = function () {
+    function number2px (n) {
+        return Math.ceil(n) + 'px';
+    }
+    var origin = this.target.bounds.origin;
+    this.textarea.style.top = number2px(origin.y);
+    this.textarea.style.left = number2px(origin.x);
+};
+
+CursorMorph.prototype.processKeyPress = function (event) {
+};
+
+CursorMorph.prototype.processKeyDown = function (event) {
+};
+
+CursorMorph.prototype.syncTextareaSelectionWith = function (targetMorph) {
+    var start = targetMorph.startMark;
+    var end = targetMorph.endMark;
+
+    if (start <= end) {
+        this.textarea.setSelectionRange(start, end, 'forward');
+    } else {
+        this.textarea.setSelectionRange(end, start, 'backward');
+    }
+    this.textarea.focus();
+};
+
+CursorMorph.prototype.destroy = function () {
+    if (this.target.alignment !== this.originalAlignment) {
+        this.target.alignment = this.originalAlignment;
+        this.target.drawNew();
+        this.target.changed();
+    }
+    this.destroyTextarea();
+    CursorMorph.uber.destroy.call(this);
+};
+
+CursorMorph.prototype.destroyTextarea = function () {
+    document.body.removeChild(this.textarea);
+    this.textarea = null;
+};
+
+StringMorph.prototype.clearSelection = function () {
+    if (!this.currentlySelecting &&
+            isNil(this.startMark) &&
+            isNil(this.endMark)) {
+        return;
+    }
+    this.currentlySelecting = false;
+    this.startMark = null;
+    this.endMark = null;
+    this.drawNew();
+    this.changed();
+};
+
+StringMorph.prototype.selectAll = function () {
+    var cursor;
+    if (this.isEditable) {
+        this.startMark = 0;
+        this.endMark = this.text.length;
+        cursor = this.root().cursor;
+        if (cursor) {
+            cursor.gotoSlot(this.text.length);
+            cursor.syncTextareaSelectionWith(this);
+        }
+        this.drawNew();
+        this.changed();
+    }
+};
+
+
+StringMorph.prototype.shiftClick = function (pos) {
+    var cursor = this.root().cursor;
+
+    if (cursor) {
+        if (!this.startMark) {
+            this.startMark = cursor.slot;
+        }
+        cursor.gotoPos(pos);
+        this.endMark = cursor.slot;
+        cursor.syncTextareaSelectionWith(this);
+        this.drawNew();
+        this.changed();
+    }
+    this.currentlySelecting = false;
+    this.escalateEvent('mouseDownLeft', pos);
+};
+
+StringMorph.prototype.mouseDoubleClick = function (pos) {
+    // selects the word at pos if there is no word, we select whatever is
+    // between the previous and next words
+    var slot = this.slotAt(pos);
+
+    if (this.isEditable) {
+        this.edit();
+
+        if (slot === this.text.length) {
+            slot -= 1;
+        }
+
+        if (this.text[slot] && isWordChar(this.text[slot])) {
+            this.selectWordAt(slot);
+        } else if (this.text[slot]) {
+            this.selectBetweenWordsAt(slot);
+        } else {
+            // special case for when we click right after the last slot in
+            // multi line TextMorphs
+            this.selectAll();
+        }
+        this.root().cursor.syncTextareaSelectionWith(this);
+    } else {
+        this.escalateEvent('mouseDoubleClick', pos);
+    }
+};
+
+StringMorph.prototype.enableSelecting = function () {
+    this.mouseDownLeft = function (pos) {
+        var crs = this.root().cursor;
+        var already = crs ? crs.target === this : false;
+        if (this.world().currentKey === 16) {
+            this.shiftClick(pos);
+        } else {
+            this.clearSelection();
+            if (this.isEditable && (!this.isDraggable)) {
+                this.edit();
+                this.root().cursor.gotoPos(pos);
+                this.startMark = this.slotAt(pos);
+                this.endMark = this.startMark;
+                this.currentlySelecting = true;
+                this.root().cursor.syncTextareaSelectionWith(this);
+                if (!already) {this.escalateEvent('mouseDownLeft', pos); }
+            }
+        }
+    };
+    this.mouseMove = function (pos) {
+        if (this.isEditable &&
+                this.currentlySelecting &&
+                (!this.isDraggable)) {
+            var newMark = this.slotAt(pos);
+            if (newMark !== this.endMark) {
+                this.endMark = newMark;
+                var cursor = this.root().cursor;
+                if (cursor) {
+                    cursor.syncTextareaSelectionWith(this);
+                }
+                this.drawNew();
+                this.changed();
+            }
+        }
+    };
+};
+
+WorldMorph.prototype.edit = function (aStringOrTextMorph) {
+    if (this.cursor && this.cursor.target === aStringOrTextMorph) {
+        return;
+    }
+
+    var pos = getDocumentPositionOf(this.worldCanvas);
+
+    if (!aStringOrTextMorph.isEditable) {
+        return null;
+    }
+    if (this.cursor) {
+        this.cursor.destroy();
+    }
+    this.cursor = new CursorMorph(aStringOrTextMorph);
+    aStringOrTextMorph.parent.add(this.cursor);
+    this.keyboardReceiver = this.cursor;
+
+    this.initVirtualKeyboard();
+    if (MorphicPreferences.isTouchDevice
+            && MorphicPreferences.useVirtualKeyboard) {
+        this.virtualKeyboard.style.top = this.cursor.top() + pos.y + "px";
+        this.virtualKeyboard.style.left = this.cursor.left() + pos.x + "px";
+        this.virtualKeyboard.focus();
+    }
+
+    if (MorphicPreferences.useSliderForInput) {
+        if (!aStringOrTextMorph.parentThatIsA(MenuMorph)) {
+            this.slide(aStringOrTextMorph);
+        }
+    }
+
+    if (this.lastEditedText !== aStringOrTextMorph) {
+        aStringOrTextMorph.escalateEvent('freshTextEdit', aStringOrTextMorph);
+    }
+    this.lastEditedText = aStringOrTextMorph;
+};

--- a/src/morphic.js
+++ b/src/morphic.js
@@ -1042,7 +1042,7 @@
     canvasses for simple shapes in order to save system resources and
     optimize performance. Examples are costumes and backgrounds in Snap.
     In Morphic you can create new canvas elements using
-    
+
         newCanvas(extentPoint [, nonRetinaFlag])
 
     If retina support is enabled such new canvasses will automatically be
@@ -1083,12 +1083,12 @@
     stepping mechanism.
 
     For an example how to use animations look at how the Morph's methods
-    
+
         glideTo()
         fadeTo()
 
     and
-    
+
         slideBackTo()
 
     are implemented.
@@ -1445,7 +1445,7 @@ function copy(target) {
     canvasses for simple shapes in order to save system resources and
     optimize performance. Examples are costumes and backgrounds in Snap.
     In Morphic you can create new canvas elements using
-    
+
         newCanvas(extentPoint [, nonRetinaFlag])
 
     If retina support is enabled such new canvasses will automatically be
@@ -1479,7 +1479,7 @@ function enableRetinaSupport() {
 
     NOTE: This implementation is not exhaustive; it only implements what is
     needed by the Snap! UI.
-    
+
     [Jens]: like all other retina screen support implementations I've seen
     Bartosz's patch also does not address putImageData() compatibility when
     mixing retina-enabled and non-retina canvasses. If you need to manipulate
@@ -1617,7 +1617,7 @@ function enableRetinaSupport() {
     contextProto.drawImage = function(image) {
         var pixelRatio = getPixelRatio(image),
             sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight;
-        
+
         // Different signatures of drawImage() method have different
         // parameter assignments.
         switch (arguments.length) {
@@ -1809,12 +1809,12 @@ function normalizeCanvas(aCanvas, getCopy) {
     stepping mechanism.
 
     For an example how to use animations look at how the Morph's methods
-    
+
         glideTo()
         fadeTo()
 
     and
-    
+
         slideBackTo()
 
     are implemented.
@@ -6470,7 +6470,7 @@ DialMorph.prototype.drawNew = function () {
     );
     ctx.closePath();
     ctx.fill();
-    
+
     // fill value
     angle = (this.value - this.min) * (Math.PI * 2) / range - Math.PI / 2;
     ctx.fillStyle = (this.fillColor || this.color.darker()).toString();
@@ -8739,7 +8739,7 @@ StringMorph.prototype.previousWordFrom = function (aSlot) {
     // answer the slot (index) slots indicating the position of the
     // previous word to the left of aSlot
     var index = aSlot - 1;
-    
+
     // while the current character is non-word one, we skip it, so that
     // if we are in the middle of a non-alphanumeric sequence, we'll get
     // right to the beginning of the previous word
@@ -8758,7 +8758,7 @@ StringMorph.prototype.previousWordFrom = function (aSlot) {
 
 StringMorph.prototype.nextWordFrom = function (aSlot) {
     var index = aSlot;
-    
+
     while (index < this.endOfLine() && !isWordChar(this.text[index])) {
         index += 1;
     }


### PR DESCRIPTION
#### Summary

Included in this PR, is another attempt of the "ghost textarea" method of IME support, as discussed in:

* [#1103](https://github.com/jmoenig/Snap/pull/1103) Enable IME Composing for some diacritics on Mac OS #4 X & ideograms #1047 & Android virtual keyboard
* [#1214](https://github.com/jmoenig/Snap/pull/1214) IME composition support

I tried the patches submitted in #1214 with the newest source tree, it kind of works. But since a lot of code changed in morphic.js, the merge is not very clean and includes a lot guess work. This is a new attempt, borrowed some code of the initialization function of #1214, and then toke a different road from #1214 .

The main difference is that in this PR, the `textarea` take care of handling all keyboard events, so the `CursorMorph` can do much less work, mostly acts as a visual representation of the cursor. As a result, the information flow between the `textarea` and `CursorMorph` is in single direction and minimized.

#### Motivation
On the one hand, I think some features like local variables, ability of creating reporter blocks, first class lists, together with the block based programming, make a great platform to teach kid  modular programming.

On the other hand, being able to input, display their native languages helps a lot in engaging the students in learning programming. The browser environment that Snap! runs in already have a good support for this, so I really hope Snap! can support it too.

In short: I like it, I want it to be better.
####  The design
 - Upon an edit session starts, a hidden `textarea` is created, initialized with the contents of the `Morph` to be edited.
 - The `textarea` will have keyboard focus all the time, handles all keyboard events: navigation, selection and insertion/deletion.
 - After each `keyup` event, the result content and status of selection is updated for the target `Morph`, and the caret position is updated for the `CursorMorph`.
 - The target `Morph` handles all the mouse events, which will only change the cursor position and status of selection.
 - After each mouse events, the status of selection, the position of cursor are reported to the `textarea`.

#### Improvements made by these changes:
 - The main goal is archived:
    Now user can input texts in languages that needs an input method.
 - As side effects, two more bugs are fixed:
   * Shift+click always select all text, does not select text as expected.
   * Numeric input slots accept invalid inputs like "10-2" (but treat it as 10, which is the returned value by parseFloat, I guess), "10.0.2", so one can put "10-2" in sqrt block, and got '3.16...'(sqrt(10)) back
 
#### Behavior change that might affect other part of system:
 *  Method `WorldMorph.edit`: I added a guard at the start of the function, so that  a new edit session is created only if the target morph is different from the one that is currently being edited. This is related to the above mentioned  "shift+click" bug, which is caused by always creating new edit session, even for the target Morph that is being edited.

     As far as I can tell, this changes does not affect other parts of the program.
 
####  Features that are not ported
 *    In the handling of ctrl(cmd)-keys, some special combinations of keys are  supported, for example `ctrl + F12` will insert '{'. Is there any device that needs these combinations? I've never heard of shortcut like this. If needed, I think they can be ported by synthetic events or directly the value of `textarea`.
 