### PR TITLE
Provide IME support to text editing using hidden textarea

### DIFF
--- a/src/blocks.js
+++ b/src/blocks.js
@@ -9055,14 +9055,9 @@ InputSlotMorph.prototype.fixLayout = function () {
 // InputSlotMorph events:
 
 InputSlotMorph.prototype.mouseDownLeft = function (pos) {
-    var world;
     if (this.isReadOnly || this.arrow().bounds.containsPoint(pos)) {
         this.escalateEvent('mouseDownLeft', pos);
     } else {
-        world = this.world();
-        if (world) {
-            world.stopEditing();
-        }
         this.selectForEdit().contents().edit();
     }
 };

--- a/src/morphic.js
+++ b/src/morphic.js
@@ -5418,7 +5418,7 @@ CursorMorph.prototype.initializeTextarea = function () {
         }
     });
 
-    // For other keyboard events, let the textarea element handle other key 
+    // For other keyboard events, first let the textarea element handle the
     // events, then we take its state and update the target morph and cursor
     // morph accordingly.
     this.textarea.addEventListener('keyup', function (event) {
@@ -5498,7 +5498,9 @@ CursorMorph.prototype.syncTextareaSelectionWith = function (targetMorph) {
     var start = targetMorph.startMark;
     var end = targetMorph.endMark;
 
-    if (start <= end) {
+    if (start === end) {
+        this.textarea.setSelectionRange(this.slot, this.slot, 'none');
+    } else if (start < end) {
         this.textarea.setSelectionRange(start, end, 'forward');
     } else {
         this.textarea.setSelectionRange(end, start, 'backward');

--- a/src/morphic.js
+++ b/src/morphic.js
@@ -5357,73 +5357,153 @@ CursorMorph.prototype.init = function (aStringOrTextMorph) {
         this.target.setAlignmentToLeft();
     }
     this.gotoSlot(this.slot);
-    this.initializeClipboardHandler();
+    this.initializeTextarea();
 };
 
-CursorMorph.prototype.initializeClipboardHandler = function () {
-    // Add hidden text box for copying and pasting
-    var myself = this,
-        wrrld = this.target.world();
+CursorMorph.prototype.initializeTextarea = function () {
+    var myself = this;
 
-    this.clipboardHandler = document.createElement('textarea');
-    this.clipboardHandler.style.position = 'absolute';
-    this.clipboardHandler.style.top = window.outerHeight;
-    this.clipboardHandler.style.right = '101%'; // placed just out of view
+    this.textarea = document.createElement('textarea');
+    this.textarea.style.zIndex = -1;
+    this.textarea.style.position = 'absolute';
+    this.textarea.wrap = "off";
+    this.textarea.style.overflow = "hidden";
+    this.textarea.style.fontSize = this.target.fontSize + 'px';
+    this.textarea.autofocus = true;
+    this.textarea.value = this.target.text;
+    document.body.appendChild(this.textarea);
+    this.updateTextAreaPosition();
+    this.syncTextareaSelectionWith(this.target);
 
-    document.body.appendChild(this.clipboardHandler);
 
-    this.clipboardHandler.value = this.target.selection();
-    this.clipboardHandler.focus();
-    this.clipboardHandler.select();
+    /* The following keyboard events causes special actions in Snap, so we
+    don't want the textarea to handle it:
+    - ctrl-d, ctrl-i and ctrl-p: doit, inspect it and print it
+    - tab: goto next text field
+    - esc: discard the editing
+    - enter / shift+enter: accept the editing
+    */
+    this.textarea.addEventListener('keydown', function (event) {
+        // other part of the world need to know the current key
+        myself.world().currentKey = event.keyCode;
 
-    this.clipboardHandler.addEventListener(
-        'keypress',
-        function (event) {
-            myself.processKeyPress(event);
-            this.value = myself.target.selection();
-            this.select();
-        },
-        false
-    );
+        var keyName = event.key;
+        var shift = event.shiftKey;
+        var singleLineText = myself.target instanceof StringMorph;
 
-    this.clipboardHandler.addEventListener(
-        'keydown',
-        function (event) {
-            myself.processKeyDown(event);
-            if (event.shiftKey) {
-                wrrld.currentKey = 16;
+        if (!isNil(myself.target.receiver) &&
+                    (event.ctrlKey || event.metaKey)) {
+            if (keyName === 'd') {
+                myself.target.doIt();
+            } else if (keyName === 'i') {
+                myself.target.inspectIt();
+            } else if (keyName === 'p') {
+                myself.target.showIt();
             }
-            this.value = myself.target.selection();
-            this.select();
-
-            // Make sure tab prevents default
-            if (event.key === 'U+0009' ||
-                    event.key === 'Tab') {
-                myself.processKeyPress(event);
-                event.preventDefault();
+            event.preventDefault();
+        } else if (keyName === 'Tab' || keyName === 'U+0009') {
+            if (shift) {
+                myself.target.backTab(myself.target);
+            } else {
+                myself.target.tab(myself.target);
             }
-        },
-        false
-    );
+            event.preventDefault();
+            myself.target.escalateEvent('reactToEdit', myself.target);
+        } else if (keyName === 'Escape') {
+            myself.cancel();
+        } else if (keyName === "Enter" && (singleLineText || shift)) {
+            myself.accept();
+        } else {
+            myself.target.escalateEvent('reactToKeystroke', event);
+        }
+    });
 
-    this.clipboardHandler.addEventListener(
-        'keyup',
-        function (event) {
-            wrrld.currentKey = null;
-        },
-        false
-    );
+    // For other keyboard events, let the textarea element handle other key 
+    // events, then we take its state and update the target morph and cursor
+    // morph accordingly.
+    this.textarea.addEventListener('keyup', function (event) {
+        myself.world().currentKey = null;
 
-    this.clipboardHandler.addEventListener(
-        'input',
-        function (event) {
-            if (this.value === '') {
-                myself.gotoSlot(myself.target.selectionStartSlot());
-                myself.target.deleteSelection();
+        var target = myself.target;
+        var textarea = myself.textarea;
+        var filteredContent;
+        
+        // filter invalid chars for numeric fields
+        function filterText (content) {
+            var points = 0;
+            var result = '';
+            for (var i=0; i < content.length; i++) {
+                var ch = content.charAt(i);
+                var valid = (
+                    ('0' <= ch && ch <= '9') || // digits
+                    (i === 0 && ch === '-')  || // leading '-'
+                    (ch === '.' && points === 0) // at most '.'
+                );
+                if (valid) {
+                    result += ch;
+                    if (ch === '.') points++;
+                }
             }
-        },
-        false
-    );
+            return result;
+        }
+        
+        if (target.isNumeric) {
+            filteredContent = filterText(textarea.value);
+        } else {
+            filteredContent = textarea.value;
+        }
+        
+        if (filteredContent.length < textarea.value.length) {
+            textarea.value = filteredContent;
+            var caret = Math.min(textarea.selectionStart, filteredContent.length);
+            textarea.selectionEnd = caret;
+            textarea.selectionStart = caret;
+        }
+        // target morph: copy the content and selection status to the target.        
+        target.text = filteredContent;
+        if (textarea.selectionStart === textarea.selectionEnd) {
+            target.startMark = null;
+            target.endMark = null;
+        } else {
+            if (textarea.selectionDirection === 'backward') {
+                target.startMark = textarea.selectionEnd;
+                target.endMark = textarea.selectionStart;
+            } else {
+                target.startMark = textarea.selectionStart;
+                target.endMark = textarea.selectionEnd;
+            }
+        }
+        target.changed();
+        target.drawNew();
+        target.changed();
+
+        // cursor morph: copy the caret position to cursor morph.
+        myself.gotoSlot(textarea.selectionStart);
+
+        myself.updateTextAreaPosition();
+        target.escalateEvent('reactToKeystroke', event);
+    });
+};
+
+CursorMorph.prototype.updateTextAreaPosition = function () {
+    function number2px (n) {
+        return Math.ceil(n) + 'px';
+    }
+    var origin = this.target.bounds.origin;
+    this.textarea.style.top = number2px(origin.y);
+    this.textarea.style.left = number2px(origin.x);
+};
+
+CursorMorph.prototype.syncTextareaSelectionWith = function (targetMorph) {
+    var start = targetMorph.startMark;
+    var end = targetMorph.endMark;
+
+    if (start <= end) {
+        this.textarea.setSelectionRange(start, end, 'forward');
+    } else {
+        this.textarea.setSelectionRange(end, start, 'backward');
+    }
+    this.textarea.focus();
 };
 
 // CursorMorph event processing:
@@ -5796,23 +5876,13 @@ CursorMorph.prototype.destroy = function () {
         this.target.drawNew();
         this.target.changed();
     }
-    this.destroyClipboardHandler();
+    this.destroyTextarea();
     CursorMorph.uber.destroy.call(this);
 };
 
-CursorMorph.prototype.destroyClipboardHandler = function () {
-    var nodes = document.body.children,
-        each,
-        i;
-    if (this.clipboardHandler) {
-        for (i = 0; i < nodes.length; i += 1) {
-            each = nodes[i];
-            if (each === this.clipboardHandler) {
-                document.body.removeChild(this.clipboardHandler);
-                this.clipboardHandler = null;
-            }
-        }
-    }
+CursorMorph.prototype.destroyTextarea = function () {
+    document.body.removeChild(this.textarea);
+    this.textarea = null;
 };
 
 // CursorMorph utilities:
@@ -8951,10 +9021,11 @@ StringMorph.prototype.selectAll = function () {
     if (this.isEditable) {
         this.startMark = 0;
         cursor = this.root().cursor;
+        this.endMark = this.text.length;
         if (cursor) {
             cursor.gotoSlot(this.text.length);
+            cursor.syncTextareaSelectionWith(this);
         }
-        this.endMark = this.text.length;
         this.drawNew();
         this.changed();
     }
@@ -8979,6 +9050,7 @@ StringMorph.prototype.shiftClick = function (pos) {
         }
         cursor.gotoPos(pos);
         this.endMark = cursor.slot;
+        cursor.syncTextareaSelectionWith(this);
         this.drawNew();
         this.changed();
     }
@@ -9024,6 +9096,7 @@ StringMorph.prototype.mouseDoubleClick = function (pos) {
             // last slot in multi line TextMorphs
             this.selectAll();
         }
+        this.root().cursor.syncTextareaSelectionWith(this);
     } else {
         this.escalateEvent('mouseDoubleClick', pos);
     }
@@ -9076,6 +9149,7 @@ StringMorph.prototype.enableSelecting = function () {
                 this.startMark = this.slotAt(pos);
                 this.endMark = this.startMark;
                 this.currentlySelecting = true;
+                this.root().cursor.syncTextareaSelectionWith(this);
                 if (!already) {this.escalateEvent('mouseDownLeft', pos); }
             }
         }
@@ -9087,6 +9161,7 @@ StringMorph.prototype.enableSelecting = function () {
             var newMark = this.slotAt(pos);
             if (newMark !== this.endMark) {
                 this.endMark = newMark;
+                this.root().cursor.syncTextareaSelectionWith(this);
                 this.drawNew();
                 this.changed();
             }
@@ -12498,6 +12573,13 @@ WorldMorph.prototype.about = function () {
 };
 
 WorldMorph.prototype.edit = function (aStringOrTextMorph) {
+    if (this.lastEditedText === aStringOrTextMorph) {
+        return;
+    }
+    if (!isNil(this.lastEditedText)) {
+        this.stopEditing();
+    }
+
     var pos = getDocumentPositionOf(this.worldCanvas);
 
     if (!aStringOrTextMorph.isEditable) {

--- a/src/morphic.js
+++ b/src/morphic.js
@@ -5421,7 +5421,7 @@ CursorMorph.prototype.initializeTextarea = function () {
     // For other keyboard events, first let the textarea element handle the
     // events, then we take its state and update the target morph and cursor
     // morph accordingly.
-    this.textarea.addEventListener('keyup', function (event) {
+    this.textarea.addEventListener('input', function (event) {
         myself.world().currentKey = null;
 
         var target = myself.target;
@@ -5461,6 +5461,7 @@ CursorMorph.prototype.initializeTextarea = function () {
         }
         // target morph: copy the content and selection status to the target.        
         target.text = filteredContent;
+        
         if (textarea.selectionStart === textarea.selectionEnd) {
             target.startMark = null;
             target.endMark = null;
@@ -5481,7 +5482,29 @@ CursorMorph.prototype.initializeTextarea = function () {
         myself.gotoSlot(textarea.selectionStart);
 
         myself.updateTextAreaPosition();
-        target.escalateEvent('reactToKeystroke', event);
+        //target.escalateEvent('reactToKeystroke', event);
+    });
+    
+    this.textarea.addEventListener('keyup', function (event) {
+        var textarea = myself.textarea;
+        var target = myself.target;
+        
+        if (textarea.selectionStart === textarea.selectionEnd) {
+            target.startMark = null;
+            target.endMark = null;
+        } else {
+            if (textarea.selectionDirection === 'backward') {
+                target.startMark = textarea.selectionEnd;
+                target.endMark = textarea.selectionStart;
+            } else {
+                target.startMark = textarea.selectionStart;
+                target.endMark = textarea.selectionEnd;
+            }
+        }
+        target.changed();
+        target.drawNew();
+        target.changed();
+        myself.gotoSlot(textarea.selectionEnd);
     });
 };
 


### PR DESCRIPTION
#### Summary

Included in this PR, is another attempt of the "ghost textarea" method of IME support, as discussed in:

* [#1103](https://github.com/jmoenig/Snap/pull/1103) Enable IME Composing for some diacritics on Mac OS #4 X & ideograms #1047 & Android virtual keyboard
* [#1214](https://github.com/jmoenig/Snap/pull/1214) IME composition support

I tried the patches submitted in #1214 with the newest source tree, it kind of works. But since a lot of code changed in morphic.js, the merge is not very clean and includes a lot guess work. This is a new attempt, borrowed some code of the initialization function of #1214, and then toke a different road from #1214 .

The main difference is that in this PR, the `textarea` take care of handling all keyboard events, so the `CursorMorph` can do much less work, mostly acts as a visual representation of the cursor. As a result, the information flow between the `textarea` and `CursorMorph` is in single direction and minimized.

#### Motivation
On the one hand, I think some features like local variables, ability of creating reporter blocks, first class lists, together with the block based programming, make a great platform to teach kid  modular programming.

On the other hand, being able to input, display their native languages helps a lot in engaging the students in learning programming. The browser environment that Snap! runs in already have a good support for this, so I really hope Snap! can support it too.

In short: I like it, I want it to be better.
####  The design
 - Upon an edit session starts, a hidden `textarea` is created, initialized with the contents of the `Morph` to be edited.
 - The `textarea` will have keyboard focus all the time, handles all keyboard events: navigation, selection and insertion/deletion.
 - After each `keyup` event, the result content and status of selection is updated for the target `Morph`, and the caret position is updated for the `CursorMorph`.
 - The target `Morph` handles all the mouse events, which will only change the cursor position and status of selection.
 - After each mouse events, the status of selection, the position of cursor are reported to the `textarea`.

#### Improvements made by these changes:
 - The main goal is archived:
    Now user can input texts in languages that needs an input method.
 - As side effects, two more bugs are fixed:
   * Shift+click always select all text, does not select text as expected.
   * Numeric input slots accept invalid inputs like "10-2" (but treat it as 10, which is the returned value by parseFloat, I guess), "10.0.2", so one can put "10-2" in sqrt block, and got '3.16...'(sqrt(10)) back
 
#### Behavior change that might affect other part of system:
 *  Method `WorldMorph.edit`: I added a guard at the start of the function, so that  a new edit session is created only if the target morph is different from the one that is currently being edited. This is related to the above mentioned  "shift+click" bug, which is caused by always creating new edit session, even for the target Morph that is being edited.

     As far as I can tell, this changes does not affect other parts of the program.
 
####  Features that are not ported
 *    In the handling of ctrl(cmd)-keys, some special combinations of keys are  supported, for example `ctrl + F12` will insert '{'. Is there any device that needs these combinations? I've never heard of shortcut like this. If needed, I think they can be ported by synthetic events or directly the value of `textarea`.
 