### PR TITLE
Fix a bug of the project note editing dialog

### DIFF
--- a/src/gui.js
+++ b/src/gui.js
@@ -3749,7 +3749,6 @@ IDE_Morph.prototype.editProjectNotes = function () {
     var dialog = new DialogBoxMorph().withKey('projectNotes'),
         frame = new ScrollFrameMorph(),
         text = new TextMorph(this.projectNotes || ''),
-        ok = dialog.ok,
         myself = this,
         size = 250,
         world = this.world();
@@ -3776,10 +3775,13 @@ IDE_Morph.prototype.editProjectNotes = function () {
     frame.addContents(text);
     text.drawNew();
 
-    dialog.ok = function () {
-        myself.projectNotes = text.text;
-        ok.call(this);
-    };
+    dialog.getInput = function () {
+        return text.text;
+    }
+    dialog.target = myself;
+    dialog.action = function (note) {
+        myself.projectNotes = note;
+    }
 
     dialog.justDropped = function () {
         text.edit();


### PR DESCRIPTION
#### Summary

Fixed a bug of the project note editing dialog.

#### How to reproduce the bug
1. open project note editor
2. make a change
3. press "Shift + Enter", the dialog is closed
4. open project note editor again, the previous change is lost

#### Fix
In `IDE_Morph.prototype.editProjectNotes`, setup `dialog.target`, `dialog.action` and `dialog.getInput` properly as required by `DialogBoxMorph.accept` method, so that the `accept` method will save the result of edit before the dialog is closed.

Changes are made in src/gui.js, but the 'why' part is in the DialogBoxMorph.accept method of the file src/widget.js.