### PR TITLE
Removes JS error when clicking on "play sound until done" with no sound selected

### DIFF
--- a/src/threads.js
+++ b/src/threads.js
@@ -2226,7 +2226,7 @@ Process.prototype.doPlaySoundUntilDone = function (name) {
     if (this.context.activeAudio === null) {
         this.context.activeAudio = sprite.playSound(name);
     }
-    if (this.context.activeAudio.ended
+    if (name === null || this.context.activeAudio.ended
             || this.context.activeAudio.terminated) {
         return null;
     }


### PR DESCRIPTION
Fixes this JS error:

![captura de pantalla de 2019-02-20 09-18-29](https://user-images.githubusercontent.com/1016697/53076669-83d3c500-34f0-11e9-9ff7-a83efe37ab00.png)

I had noticed it before, but this time it popped up while I was recording a video and I thought it'd be easier to fix it than to explain what the error meant :)