### PR TITLE
Allow loading downloaded scripts that contain custom blocks

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -1085,6 +1085,14 @@ SnapSerializer.prototype.loadScript = function (model, object) {
     // private
     var topBlock, block, nextBlock,
         myself = this;
+
+    // Check whether we're importing a single script, not a script as part of a
+    // whole project
+    if (!this.project.stage) {
+        this.project.stage = object.parentThatIsA(StageMorph);
+        this.project.targetStage = this.project.stage;
+    }
+
     model.children.forEach(function (child) {
         nextBlock = myself.loadBlock(child, false, object);
         if (!nextBlock) {
@@ -1122,6 +1130,7 @@ SnapSerializer.prototype.loadBlock = function (model, isReporter, object) {
     // private
     var block, info, inputs, isGlobal, receiver, migration,
         migrationOffset = 0;
+
     if (model.tag === 'block') {
         if (Object.prototype.hasOwnProperty.call(
                 model.attributes,


### PR DESCRIPTION
When working on Paul's project I constantly need to copy snippets from a project to another, and importing a script that includes custom blocks was giving out an error.

This doesn't pull the _definition_ of the custom block, but it lets you import it if the definition is there.

Not sure if you'll like the way I detect whether we're importing a single script. I wanted to touch as little code from store.js as possible, so this seemed like an okay way to me.