### PR TITLE
fixed getCollections method

### DIFF
--- a/src/cloud.js
+++ b/src/cloud.js
@@ -1017,14 +1017,16 @@ Cloud.prototype.getCollections = function (
     onSuccess,
     onError
 ) {
+    var dict = {
+        page: page,
+        pageSize: page ? pageSize | 16 : '',
+    };
+
+    if (searchTerm) { dict.matchtext = encodeURIComponent(searchTerm); }
+
     this.request(
         'GET',
-        '/collections?' +
-            this.encodeDict({
-                page: page,
-                pageSize: page ? pageSize | 16 : '',
-                matchtext: encodeURIComponent(searchTerm)
-            }),
+        '/collections?' + this.encodeDict(dict),
         onSuccess,
         onError,
         'Could not fetch collections'


### PR DESCRIPTION
Fixes a small isse with `null` search terms being converted into the `"null"` string and thus returning only collections with the string `"null"` in their name or description.