### PR TITLE
Support horizontal scrolling (hold shift)

### DIFF
--- a/src/morphic.js
+++ b/src/morphic.js
@@ -11456,16 +11456,22 @@ HandMorph.prototype.processMouseScroll = function (event) {
         morph = morph.parent;
     }
     if (morph) {
+        var x = event.deltaX;
+        var y = event.deltaY;
+        if (event.shiftKey && event.deltaX === 0) {
+            // Scroll horizontally (based on vertical scroll delta). This is
+            // needed for some browser/system combinations which do not set
+            // deltaX.
+            x = y;
+            y = 0; // Don't scroll vertically.
+        }
+
+        // Multiplier variable, to account for both pixel and line deltaModes.
+        var multiplier = event.deltaMode === 0x1 ? -1/3 : -1/53;
+
         morph.mouseScroll(
-            (event.detail / -3) || (
-                Object.prototype.hasOwnProperty.call(
-                    event,
-                    'wheelDeltaY'
-                ) ?
-                        event.wheelDeltaY / 120 :
-                        event.wheelDelta / 120
-            ),
-            event.wheelDeltaX / 120 || 0
+            y * multiplier,
+            x * multiplier
         );
     }
 };
@@ -12096,16 +12102,8 @@ WorldMorph.prototype.initEventListeners = function () {
         false
     );
 
-    canvas.addEventListener( // Safari, Chrome
-        "mousewheel",
-        function (event) {
-            myself.hand.processMouseScroll(event);
-            event.preventDefault();
-        },
-        false
-    );
-    canvas.addEventListener( // Firefox
-        "DOMMouseScroll",
+    canvas.addEventListener(
+        "wheel",
         function (event) {
             myself.hand.processMouseScroll(event);
             event.preventDefault();


### PR DESCRIPTION
This PR makes Snap! scroll elements horizontally when you hold shift - it's a standard interaction in almost all desktop and web apps. It also make it so Snap! uses the standardized `'wheel'` event, instead of non-standard/obsolete alternatives.

In actuality, this PR is extremely similar to one I made for Scratch 3.0: LLK/scratch-blocks#1670.

Tested in Firefox and Chromium! Definitely worth checking on a device with a trackpad (i.e. a macbook) before merging; I haven't got access to one ATM, so I haven't tried myself.

/cc @cycomachead!