### PR TITLE
fixes collection grid page size

### DIFF
--- a/src/cloud.js
+++ b/src/cloud.js
@@ -982,7 +982,7 @@ Cloud.prototype.getUserCollections = function (
             '/collections?' +
             this.encodeDict({
                 page: page || '',
-                pageSize: page ? pageSize | 16 : '',
+                pagesize: page ? pageSize || 16 : '',
                 matchtext: searchTerm ? encodeURIComponent(searchTerm) : ''
             }),
         onSuccess,
@@ -1025,7 +1025,7 @@ Cloud.prototype.getCollections = function (
 ) {
     var dict = {
         page: page,
-        pageSize: page ? pageSize | 16 : '',
+        pagesize: page ? pageSize || 16 : '',
     };
 
     if (searchTerm) { dict.matchtext = encodeURIComponent(searchTerm); }


### PR DESCRIPTION
A stray uppercase character and a missing | were causing collection grid sizes to be ignored by the backend:

![image](https://user-images.githubusercontent.com/1016697/60381871-3269b280-9a5b-11e9-845b-52872715a51a.png)

This fixes it :)