### PR TITLE
allMessageNames function working with the new specialOptionMenus

### DIFF
--- a/src/objects.js
+++ b/src/objects.js
@@ -5484,11 +5484,11 @@ SpriteMorph.prototype.allMessageNames = function () {
     all.forEach(function (script) {
         script.allChildren().forEach(function (morph) {
             var txt;
-            if (morph.selector && contains(
-                ['receiveMessage', 'doBroadcast', 'doBroadcastAndWait'],
-                morph.selector
+            if (morph instanceof InputSlotMorph && morph.choices && contains(
+                ['messagesMenu', 'messagesReceivedMenu'],
+                morph.choices
             )) {
-                txt = morph.inputs()[0].evaluate();
+                txt = morph.evaluate();
                 if (isString(txt) && txt !== '') {
                     if (!contains(msgs, txt)) {
                         msgs.push(txt);


### PR DESCRIPTION
This PR updates _allMessageNames_ function to work with the new specialOptionMenus.

The search is updated to do it inside all  _inputSlotMorphs_ that contain a  'messagesMenu' or 'messagesReceivedMenu' _choice_.

![newAllMessageNames](https://user-images.githubusercontent.com/2926315/60955350-f0fdc080-a300-11e9-96f4-ce2c4bcd6c91.png)

Thanks

Joan