### PR TITLE
Removing 'any message' from messageSpecialOptionMenu

### DIFF
--- a/src/byob.js
+++ b/src/byob.js
@@ -324,7 +324,7 @@ CustomBlockDefinition.prototype.dropDownMenuOf = function (inputName) {
             fname = this.declarations.get(inputName)[2].slice(2);
             if (contains(
                 [
-                    'messagesReceivedMenu',
+                    'messagesMenu',
                     'objectsMenu',
                     'costumesMenu',
                     'soundsMenu',
@@ -2655,7 +2655,7 @@ BlockLabelFragment.prototype.hasOptions = function () {
 BlockLabelFragment.prototype.hasSpecialMenu = function () {
     return contains(
         [
-            '§_messagesReceivedMenu',
+            '§_messagesMenu',
             '§_objectsMenu',
             '§_costumesMenu',
             '§_soundsMenu',
@@ -3764,7 +3764,7 @@ InputSlotDialogMorph.prototype.specialOptionsMenu = function () {
     }
 
     addSpecialOptions('(none)', '');
-    addSpecialOptions('messages', '§_messagesReceivedMenu');
+    addSpecialOptions('messages', '§_messagesMenu');
     addSpecialOptions('objects', '§_objectsMenu');
     // addSpecialOptions('data types', '§_typesMenu');
     addSpecialOptions('costumes', '§_costumesMenu');

--- a/src/byob.js
+++ b/src/byob.js
@@ -325,6 +325,7 @@ CustomBlockDefinition.prototype.dropDownMenuOf = function (inputName) {
             if (contains(
                 [
                     'messagesMenu',
+                    'messagesReceivedMenu',    //for backward (5.0.0 - 5.0.3) support
                     'objectsMenu',
                     'costumesMenu',
                     'soundsMenu',
@@ -2656,6 +2657,7 @@ BlockLabelFragment.prototype.hasSpecialMenu = function () {
     return contains(
         [
             '§_messagesMenu',
+            '§_messagesReceivedMenu',    //for backward (5.0.0 - 5.0.3) support
             '§_objectsMenu',
             '§_costumesMenu',
             '§_soundsMenu',


### PR DESCRIPTION
This PR changes 'message' _specialOptionMenu to avoid 'any message' option.

It really changes from "messagesReceivedMenu"  to " messagesMenu" _choice_ .

The reason is that "any message" has no sense (I think) here. Our custom blocks will treat as a "string message" and it will not have the possibilities of our hat "When I receive" block

![messageSpecialOption](https://user-images.githubusercontent.com/2926315/60956649-8601b900-a303-11e9-8bd5-f82b357e61ea.png)

Thanks

Joan