### PR TITLE
fixes bug when fetching collection list from community site

### DIFF
--- a/src/cloud.js
+++ b/src/cloud.js
@@ -980,11 +980,15 @@ Cloud.prototype.getUserCollections = function (
                 encodeURIComponent(collectionUsername) :
                 '%username') +
             '/collections?' +
-            this.encodeDict({
-                page: page || '',
-                pagesize: page ? pageSize || 16 : '',
-                matchtext: searchTerm ? encodeURIComponent(searchTerm) : ''
-            }),
+            this.encodeDict(
+                page > 0 ?
+                    {
+                        page: page
+                        pagesize: pageSize || 16,
+                        matchtext:
+                            searchTerm ? encodeURIComponent(searchTerm) : ''
+                    } : {}
+            ),
         onSuccess,
         onError,
         'Could not fetch collections'


### PR DESCRIPTION
This was totally my fault. I can't remember when I broke this, but I did :disappointed:

It'd be great if it could be integrated quickly, as right now nobody can add any projects to collections because of this... :(