### PR TITLE
fixes importing OGGs in Firefox

### DIFF
--- a/src/morphic.js
+++ b/src/morphic.js
@@ -11771,7 +11771,10 @@ HandMorph.prototype.processDrop = function (event) {
                 readSVG(file);
             } else if (file.type.indexOf("image") === 0) {
                 readImage(file);
-            } else if (file.type.indexOf("audio") === 0) {
+            } else if (file.type.indexOf("audio") === 0 ||
+                    file.type.indexOf("ogg") > -1) {
+                    // check the file-extension because Firefox
+                    // thinks OGGs are videos
                 readAudio(file);
             } else if ((file.type.indexOf("text") === 0) ||
                     contains(['txt', 'csv', 'json'], suffix)) {


### PR DESCRIPTION
As reported in the forum: https://forum.snap.berkeley.edu/t/ogg-sound-files/681/6

This addresses this bug in Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1240259