### PR TITLE
Fix auto-playing audio not working on load

### DIFF
--- a/src/objects.js
+++ b/src/objects.js
@@ -3571,6 +3571,7 @@ SpriteMorph.prototype.doPlaySound = function (name) {
     if (sound) {
         aud = document.createElement('audio');
         aud.src = sound.audio.src;
+        ctx.resume();
         source = ctx.createMediaElementSource(aud);
         source.connect(gain);
         if (pan) {


### PR DESCRIPTION
Chrome doesn't want to play audio before some sort of user interaction happens, but we still need to call `resume()` on the audio context so that Chrome re-checks whether a user interaction has happened.