### PR TITLE
Sprite touching : first row, column included, Issue #2476

### DIFF
--- a/src/morphic.js
+++ b/src/morphic.js
@@ -4481,7 +4481,7 @@ Morph.prototype.isTouching = function (otherMorph) {
         return false;
     }
     data = oImg.getContext('2d')
-        .getImageData(1, 1, oImg.width, oImg.height)
+        .getImageData(0, 0, oImg.width, oImg.height)
         .data;
     len = data.length;
     for(i = 3; i < len; i += 4) {


### PR DESCRIPTION
Sprite "touching" detection now start at (0,0 not (1,1 . #2476 