### PR TITLE
Remove extra comma in Galician translation

### DIFF
--- a/locale/lang-gl.js
+++ b/locale/lang-gl.js
@@ -1024,7 +1024,7 @@ SnapTranslator.dict.gl = {
     'detach from':
         'soltar de',
     'detach all parts':
-        'soltar todas as partes',able
+        'soltar todas as partes',
     'export...':
         'exportar…',
     'parent...':

--- a/locale/lang-gl.js
+++ b/locale/lang-gl.js
@@ -413,7 +413,7 @@ SnapTranslator.dict.gl = {
     'pen down':
         'baixar lapis',
     'pen up':
-        'subir lapis',,
+        'subir lapis',
     'pen down?':
         'lapis abaixo?',
     'set pen color to %clr':

--- a/locale/lang-gl.js
+++ b/locale/lang-gl.js
@@ -2502,10 +2502,10 @@ SnapTranslator.dict.gl = {
 	'Please make sure your web browser is up to date\nand your camera is properly configured. \n\nSome browsers also require you to access Snap!\nthrough HTTPS to use the camera.\n\nPlase replace the "http://" part of the address\nin your browser by "https://" and try again.':
         'Comprobe que o navegador está actualizado\ne a webcam ben configurada.\n\nAlgúns navegadores tamén requiren\nHTTPS para empregar a cámara.\n\nPode probalo cambiando o enderezo «http://»\npor «https://»".',
     'Uploading ':
-        'Enviando,
+        'Enviando',
     'Repeat Password:':
         'Repite o contrasinal:',
-    '%asp at %loc' :
+    '%asp at %loc':
         '%asp en %loc' ,
     'sprites':
         'obxectos',


### PR DESCRIPTION
It was preventing the translation from loading at all. Reported by @mbouzada.