### PR TITLE
Show a link to the community page for current project

### DIFF
--- a/src/cloud.js
+++ b/src/cloud.js
@@ -47,8 +47,8 @@ function Cloud() {
 }
 
 Cloud.prototype.init = function () {
-    this.urlBasePath = '/api/v1';
-    this.url = this.determineCloudDomain() + this.urlBasePath;
+    this.apiBasePath = '/api/v1';
+    this.url = this.determineCloudDomain() + this.apiBasePath;
     this.username = null;
 };
 
@@ -1098,3 +1098,17 @@ Cloud.prototype.removeEditorFromCollection = function (
         'Could not remove editor from collection'
     );
 };
+
+// Paths to front-end pages
+/*
+    This list of paths is incomplete, we will add them as necessary.
+    Important: a path is a string *without* a domain.
+    These paths are not prefixed by `apiBasePath`.
+*/
+
+Cloud.prototype.showProjectPath = function (username, projectname) {
+    return '/project?' + this.encodeDict({
+        user: username,
+        project: projectname
+    });
+}

--- a/src/gui.js
+++ b/src/gui.js
@@ -3850,7 +3850,6 @@ IDE_Morph.prototype.newProject = function () {
     Process.prototype.enableLiveCoding = false;
     this.setProjectName('');
     this.projectNotes = '';
-    this.projectUsername = '';
     this.createStage();
     this.add(this.stage);
     this.createCorral();

--- a/src/gui.js
+++ b/src/gui.js
@@ -2637,6 +2637,19 @@ IDE_Morph.prototype.cloudMenu = function () {
             'changeCloudPassword'
         );
     }
+    if (this.hasCloudProject()) {
+        menu.addLine();
+        menu.addItem(
+            'open in community site',
+            function () {
+                var dict = myself.urlParameters();
+                window.open(
+                    myself.cloud.showProjectPath(dict.Username, dict.ProjectName),
+                    '_blank'
+                );
+            }
+        );
+    }
     if (shiftClicked) {
         menu.addLine();
         menu.addItem(
@@ -3837,6 +3850,7 @@ IDE_Morph.prototype.newProject = function () {
     Process.prototype.enableLiveCoding = false;
     this.setProjectName('');
     this.projectNotes = '';
+    this.projectUsername = '';
     this.createStage();
     this.add(this.stage);
     this.createCorral();
@@ -5890,6 +5904,18 @@ IDE_Morph.prototype.setCloudURL = function () {
         this.cloud.knownDomains
     );
 };
+
+IDE_Morph.prototype.urlParameters = function () {
+    var parameters = location.hash.slice(location.hash.indexOf(':') + 1);
+
+    return this.cloud.parseDict(parameters);
+}
+
+IDE_Morph.prototype.hasCloudProject = function () {
+    var params = this.urlParameters();
+
+    return params.hasOwnProperty('Username') && params.hasOwnProperty('ProjectName');
+}
 
 // IDE_Morph HTTP data fetching
 


### PR DESCRIPTION
If you click the cloud menu, then you can get to the community
page and have it open in a new window.

This uses the URL parameters so it's not dependent upon being
logged in, and doesn't track any state.

<img width="617" alt="Screen Shot 2019-09-25 at 2 47 55 PM" src="https://user-images.githubusercontent.com/1505907/65602153-adcbf900-dfa3-11e9-8b73-f1f673a22f27.png">
