### PR TITLE
Replace costume when type changed during edit

### DIFF
--- a/src/gui.js
+++ b/src/gui.js
@@ -2385,7 +2385,7 @@ IDE_Morph.prototype.paintNewSprite = function () {
             if (!(cos instanceof SVG_Costume))
                 cos.shrinkWrap();
             sprite.wearCostume(cos, true); // don't shadow
-            this.hasChangedMedia = true;
+            myself.hasChangedMedia = true;
             sprite.shadowAttribute('costumes');
             sprite.addCostume(cos);
         },

--- a/src/gui.js
+++ b/src/gui.js
@@ -8820,24 +8820,6 @@ WardrobeMorph.prototype.removeCostumeAt = function (idx) {
     this.updateList();
 };
 
-function createCostume(img, name, rotationCenter, shapes) {
-    var cos;
-    if (shapes)
-    {
-        if (shapes.length === 0)
-            return null;
-        cos = new SVG_Costume(img, name, rotationCenter);
-        cos.shapes = shapes;
-    }
-    else
-    {
-        cos = new Costume(img, name, rotationCenter);
-    }
-    
-    cos.version = Date.now();
-    return cos;
-}
-
 WardrobeMorph.prototype.paintNew = function () {
     var cosName = this.sprite.newCostumeName(localize('Untitled')),
         anIDE = this.parentThatIsA(IDE_Morph),

--- a/src/objects.js
+++ b/src/objects.js
@@ -1472,8 +1472,8 @@ SpriteMorph.prototype.initBlockMigrations = function () {
             offset: 1
         },
         reportDistanceTo: {
-        	selector: 'reportRelationTo',
-         	inputs: [['distance']],
+            selector: 'reportRelationTo',
+            inputs: [['distance']],
             offset: 1
         },
         comeToFront: {
@@ -2442,9 +2442,9 @@ SpriteMorph.prototype.blockTemplates = function (category) {
             blocks.push(block('reportFrameCount'));
         }
 
-	/////////////////////////////////
+    /////////////////////////////////
 
-		blocks.push('=');
+        blocks.push('=');
         blocks.push(this.makeBlockButton(cat));
 
     } else if (cat === 'operators') {
@@ -2489,7 +2489,7 @@ SpriteMorph.prototype.blockTemplates = function (category) {
             blocks.push('-');
             blocks.push(block('reportJSFunction'));
             if (Process.prototype.enableCompiling) {
-	            blocks.push(block('reportCompiled'));
+                blocks.push(block('reportCompiled'));
             }
         }
 
@@ -2646,15 +2646,15 @@ SpriteMorph.prototype.blockTemplates = function (category) {
 
         blocks.push(this.makeBlockButton());
 
- 	}
+    }
     return blocks;
 };
 
 SpriteMorph.prototype.makeBlockButton = function (category) {
-	// answer a button that prompts the user to make a new block
+    // answer a button that prompts the user to make a new block
     var button = new PushButtonMorph(
         this,
-		'makeBlock',
+        'makeBlock',
         'Make a block'
     );
 
@@ -2754,7 +2754,7 @@ SpriteMorph.prototype.freshPalette = function (category) {
     searchButton.labelShadowColor = shade;
     searchButton.drawNew();
     searchButton.fixLayout();
-	palette.toolBar.add(searchButton);
+    palette.toolBar.add(searchButton);
 
     makeButton = new PushButtonMorph(
         this,
@@ -2769,7 +2769,7 @@ SpriteMorph.prototype.freshPalette = function (category) {
     makeButton.fixLayout();
     palette.toolBar.add(makeButton);
 
-	palette.toolBar.fixLayout();
+    palette.toolBar.fixLayout();
     palette.add(palette.toolBar);
 
     // menu:
@@ -3960,12 +3960,12 @@ SpriteMorph.prototype.initClone = function (hats) {
 
 SpriteMorph.prototype.removeClone = function () {
     var exemplar = this.exemplar,
-    	myself = this;
+        myself = this;
     if (this.isTemporary) {
         // this.stopTalking();
         this.parent.threads.stopAllForReceiver(this);
         this.parts.slice().forEach(function (part) {
-        	myself.detachPart(part);
+            myself.detachPart(part);
             part.removeClone();
         });
         this.corpsify();
@@ -3984,7 +3984,7 @@ SpriteMorph.prototype.perpetuate = function () {
     var stage = this.parentThatIsA(StageMorph),
         ide = this.parentThatIsA(IDE_Morph);
 
-	// make sure my exemplar-chain is fully perpetuated
+    // make sure my exemplar-chain is fully perpetuated
     if (this.exemplar) {
         this.exemplar.perpetuate();
     }
@@ -4023,12 +4023,12 @@ SpriteMorph.prototype.release = function () {
         return;
     }
 
-	// make sure all parts and instances are also released
+    // make sure all parts and instances are also released
     this.parts.forEach(function (part) {
         part.release();
     });
     this.instances.forEach(function (inst) {
-    	inst.release();
+        inst.release();
     });
     this.isTemporary = true;
     this.name = '';
@@ -5269,17 +5269,17 @@ SpriteMorph.prototype.forward = function (steps) {
         dist = steps * this.parent.scale || 0,
         dot = 0.1;
 
-	if (dist === 0 && this.isDown) { // draw a dot
- 		// dot = Math.min(this.size, 1);
- 		this.isDown = false;
+    if (dist === 0 && this.isDown) { // draw a dot
+        // dot = Math.min(this.size, 1);
+        this.isDown = false;
         this.forward(dot * -0.5);
         this.isDown = true;
         this.forward(dot);
         this.isDown = false;
         this.forward(dot * -0.5);
         this.isDown = true;
-     	return;
- 	} else if (dist >= 0) {
+        return;
+    } else if (dist >= 0) {
         dest = this.position().distanceAngle(dist, this.heading);
     } else {
         dest = this.position().distanceAngle(
@@ -6657,35 +6657,35 @@ SpriteMorph.prototype.hasSpriteVariable = function (varName) {
 
 SpriteMorph.prototype.allLocalVariableNames = function (sorted) {
     var exceptGlobals = this.globalVariables(),
-    	globalNames = exceptGlobals.names(),
-     	data;
+        globalNames = exceptGlobals.names(),
+        data;
 
     function alphabetically(x, y) {
         return x.toLowerCase() < y.toLowerCase() ? -1 : 1;
     }
 
- 	data = this.variables.allNames(exceptGlobals).filter(function (each) {
-		return !contains(globalNames, each);
+    data = this.variables.allNames(exceptGlobals).filter(function (each) {
+        return !contains(globalNames, each);
     });
-	if (sorted) {
- 		data.sort(alphabetically);
+    if (sorted) {
+        data.sort(alphabetically);
    }
    return data;
 };
 
 SpriteMorph.prototype.reachableGlobalVariableNames = function (sorted) {
     var locals = this.allLocalVariableNames(),
-    	data;
+        data;
 
     function alphabetically(x, y) {
         return x.toLowerCase() < y.toLowerCase() ? -1 : 1;
     }
 
-	data = this.globalVariables().names().filter(function (each) {
-    	return !contains(locals, each);
-	});
+    data = this.globalVariables().names().filter(function (each) {
+        return !contains(locals, each);
+    });
     if (sorted) {
-    	data.sort(alphabetically);
+        data.sort(alphabetically);
    }
    return data;
 };
@@ -6963,17 +6963,17 @@ SpriteMorph.prototype.destroy = function () {
 // SpriteMorph highlighting
 
 SpriteMorph.prototype.flash = function () {
-	var world = this.world(),
-		myself = this;
+    var world = this.world(),
+        myself = this;
     this.addHighlight();
-	world.animations.push(new Animation(
-		nop,
-  		nop,
-    	0,
-     	800,
-      	nop,
-      	function () {myself.removeHighlight(); }
-	));
+    world.animations.push(new Animation(
+        nop,
+        nop,
+        0,
+        800,
+        nop,
+        function () {myself.removeHighlight(); }
+    ));
 };
 
 SpriteMorph.prototype.addHighlight = function (oldHighlight) {
@@ -7633,7 +7633,7 @@ StageMorph.prototype.projectionSnap = function() {
 
 StageMorph.prototype.getPixelColor = function (aPoint) {
     var point, context, data;
-	if (this.trailsCanvas) {
+    if (this.trailsCanvas) {
         point = aPoint.subtract(this.bounds.origin);
         context = this.penTrailsMorph().image.getContext('2d');
         data = context.getImageData(point.x, point.y, 1, 1);
@@ -7649,7 +7649,7 @@ StageMorph.prototype.getPixelColor = function (aPoint) {
                     data.data[3] / 255
                 );
             }
-        	return StageMorph.uber.getPixelColor.call(this, aPoint);
+            return StageMorph.uber.getPixelColor.call(this, aPoint);
         }
         return new Color(
             data.data[0],
@@ -7657,7 +7657,7 @@ StageMorph.prototype.getPixelColor = function (aPoint) {
             data.data[2],
             data.data[3] / 255
         );
- 	}
+    }
 };
 
 // StageMorph accessing
@@ -9066,10 +9066,10 @@ StageMorph.prototype.inheritedVariableNames = function () {
 };
 
 StageMorph.prototype.allLocalVariableNames
-	= SpriteMorph.prototype.allLocalVariableNames;
+    = SpriteMorph.prototype.allLocalVariableNames;
 
 StageMorph.prototype.reachableGlobalVariableNames
-	= SpriteMorph.prototype.reachableGlobalVariableNames;
+    = SpriteMorph.prototype.reachableGlobalVariableNames;
 
 // StageMorph inheritance - custom blocks
 
@@ -9796,7 +9796,7 @@ SVG_Costume.prototype.parseShapes = function () {
 };
 
 SVG_Costume.prototype.edit = function (
-	aWorld,
+    aWorld,
     anIDE,
     isnew,
     oncancel,

--- a/src/objects.js
+++ b/src/objects.js
@@ -3435,6 +3435,11 @@ SpriteMorph.prototype.addCostume = function (costume) {
     this.costumes.add(costume);
 };
 
+SpriteMorph.prototype.replaceCostume = function (cosOld, cos) {
+    var cosIdx = this.costumes.asArray().indexOf(cosOld) + 1;
+    this.costumes.put(cos, cosIdx);
+};
+    
 SpriteMorph.prototype.wearCostume = function (costume, noShadow) {
     var x = this.xPosition ? this.xPosition() : null,
         y = this.yPosition ? this.yPosition() : null,

--- a/src/objects.js
+++ b/src/objects.js
@@ -9575,37 +9575,6 @@ Costume.prototype.stretched = function (w, h) {
 
 // Costume actions
 
-Costume.prototype.edit = function (aWorld, anIDE, isnew, oncancel, onsubmit) {
-    var myself = this,
-        editor = new PaintEditorMorph();
-    editor.oncancel = oncancel || nop;
-    editor.openIn(
-        aWorld,
-        isnew ?
-                newCanvas(StageMorph.prototype.dimensions, true) :
-                this.contents,
-        isnew ?
-                null :
-                this.rotationCenter,
-        function (img, rc) {
-            myself.contents = img;
-            myself.rotationCenter = rc;
-            myself.version = Date.now();
-            aWorld.changed();
-            if (anIDE) {
-                if (anIDE.currentSprite instanceof SpriteMorph) {
-                    // don't shrinkwrap stage costumes
-                    myself.shrinkWrap();
-                }
-                anIDE.currentSprite.wearCostume(myself, true); // don't shadow
-                anIDE.hasChangedMedia = true;
-            }
-            (onsubmit || nop)();
-        },
-        anIDE
-    );
-};
-
 Costume.prototype.editRotationPointOnly = function (aWorld) {
     var editor = new CostumeEditorMorph(this),
         action,
@@ -9798,41 +9767,6 @@ SVG_Costume.prototype.parseShapes = function () {
             return window[child.attributes.prototype].fromSVG(child);
         });
     }
-};
-
-SVG_Costume.prototype.edit = function (
-    aWorld,
-    anIDE,
-    isnew,
-    oncancel,
-    onsubmit
-) {
-    var myself = this,
-        editor;
-
-    editor = new VectorPaintEditorMorph();
-
-    editor.oncancel = oncancel || nop;
-    editor.openIn(
-        aWorld,
-        isnew ? newCanvas(StageMorph.prototype.dimensions) : this.contents,
-        isnew ? new Point(240, 180) : myself.rotationCenter,
-        function (img, rc, shapes) {
-            myself.contents = img;
-            myself.rotationCenter = rc;
-            myself.shapes = shapes;
-            myself.version = Date.now();
-            aWorld.changed();
-            if (anIDE) {
-                if (isnew) {anIDE.currentSprite.addCostume(myself); }
-                anIDE.currentSprite.wearCostume(myself);
-                anIDE.hasChangedMedia = true;
-            }
-            (onsubmit || nop)();
-        },
-        anIDE,
-        this.shapes || []
-    );
 };
 
 // SVG_Costume pixel access

--- a/src/objects.js
+++ b/src/objects.js
@@ -9376,6 +9376,28 @@ SpriteBubbleMorph.prototype.fixLayout = function () {
 
 // Costume instance creation
 
+// factory for creating correct costume type:
+// - Costume (from bitmap) if shapes is null
+// - SVG_Costume (from vector shapes) if shapes is not null
+//   (array of objects of type VectorShape expected)
+function createCostume(img, name, rotationCenter, shapes) {
+    var cos;
+    if (shapes)
+    {
+        if (shapes.length === 0)
+            return null;
+        cos = new SVG_Costume(img, name, rotationCenter);
+        cos.shapes = shapes;
+    }
+    else
+    {
+        cos = new Costume(img, name, rotationCenter);
+    }
+    
+    cos.version = Date.now();
+    return cos;
+}
+
 function Costume(canvas, name, rotationCenter) {
     this.contents = canvas ? normalizeCanvas(canvas, true)
             : newCanvas(null, true);

--- a/src/paint.js
+++ b/src/paint.js
@@ -355,17 +355,19 @@ PaintEditorMorph.prototype.cancel = function () {
 };
 
 PaintEditorMorph.prototype.switchToVector = function () {
-    var myself = this;
-    this.object = new SVG_Costume(new Image(), '', new Point(0,0));
-    this.object.edit(
-        this.world(),
-        this.ide,
-        true,
-        this.oncancel,
-        function() {
-            myself.ide.currentSprite.changed();
-        }
-    );
+    var anIDE = this.ide,
+        myself = this,
+        editor = new VectorPaintEditorMorph(),
+        aWorld = this.world();
+    editor.oncancel = this.oncancel;
+    editor.openIn(
+        aWorld,
+        new Image(),
+        null,
+        myself.callback,
+        anIDE);
+
+    this.destroy();
 };
 
 PaintEditorMorph.prototype.populatePropertiesMenu = function () {

--- a/src/sketch.js
+++ b/src/sketch.js
@@ -998,22 +998,24 @@ VectorPaintEditorMorph.prototype.buildEdits = function () {
 };
 
 VectorPaintEditorMorph.prototype.convertToBitmap = function () {
-    var canvas = newCanvas(StageMorph.prototype.dimensions);
-
-    this.object = new Costume();
+    var canvas = newCanvas(StageMorph.prototype.dimensions),
+        anIDE = this.ide,
+        myself = this,
+        editor = new PaintEditorMorph(),
+        aWorld = this.world();
 
     this.shapes.forEach(function(each) {
         canvas.getContext('2d').drawImage(each.image, 0, 0);
     });
 
-    this.object.rotationCenter = this.paper.rotationCenter.copy();
-    this.object.contents = canvas;
-    this.object.edit(
-        this.world(),
-        this.ide,
-        false,
-        this.oncancel
-    );
+
+    editor.oncancel = this.oncancel;
+    editor.openIn(
+        aWorld,
+        canvas,
+        this.paper.rotationCenter.copy(),
+        myself.callback,
+        anIDE);
 
     this.destroy();
 };
@@ -1050,17 +1052,20 @@ VectorPaintEditorMorph.prototype.openIn = function (
     this.paper.drawNew();
     this.paper.changed();
 
-    // make sure shapes are initialized and can be rendered
-    shapes.forEach(function (shape) {
-        shape.drawOn(myself.paper);
-    });
-    // copy the shapes for editing and re-render the copies
-    this.shapes = shapes.map(function (eachShape) {
-        return eachShape.copy();
-    });
-    this.shapes.forEach(function (shape) {
-        shape.drawOn(myself.paper);
-    });
+    if (shapes) {
+        // make sure shapes are initialized and can be rendered
+        shapes.forEach(function (shape) {
+            shape.drawOn(myself.paper);
+        });
+        // copy the shapes for editing and re-render the copies
+        this.shapes = shapes.map(function (eachShape) {
+            return eachShape.copy();
+        });
+        this.shapes.forEach(function (shape) {
+            shape.drawOn(myself.paper);
+        });
+    } else this.shapes = [];
+    
     // init the rotation center, if any
     if (oldrc && !isEmpty) {
         this.paper.automaticCrosshairs = false;


### PR DESCRIPTION
As discussed with bromagosa at SnapCon I propose these changes to fix issue #2492 ("Editing costume type (SVG <-> bitmap) not working properly").

The following will improve:
* new costumes will always have a unique name of the form 'Untitled' or 'Untitled(1)' ... (currently new SVG costumes will have default names of the form 'costume1', 'costume2', etc. not even guaranteeing a unique name)
* when editing a costume and changing its type while editing, the original costume will be changed as expected in all cases (currently when editing a SVG costume and changing its type to bitmap, the original costume will remain unchanged, although the sprite will wear the changed costume; and when editing a bitmap costume and changing its type to SVG the edited costume will be added as new costume)
* the code of VectorPaintEditorMorph does not depend on the Costume class any more
* the Costume class does not depend on PaintEditorMorph or VectorPaintEditorMorph any more