### PR TITLE
Do not try to preserve the aspect ratio of painted SVG costumes

### DIFF
--- a/src/sketch.js
+++ b/src/sketch.js
@@ -1535,7 +1535,7 @@ VectorPaintEditorMorph.prototype.getSVG = function () {
     svg.attributes.xmlns = 'http://www.w3.org/2000/svg';
     svg.attributes.snap = 'http://snap.berkeley.edu/run';
     svg.attributes.version = '1.1';
-    svg.attributes.preserveAspectRatio = 'xMinYMin meet';
+    svg.attributes.preserveAspectRatio = 'none meet';
     svg.attributes.viewBox =
         bounds.left() + ' ' + bounds.top() + ' ' +
         (bounds.right() - bounds.left()) + ' ' +


### PR DESCRIPTION
When creating the SVG of painted elements do not try to preserve the aspect ratio (Firefox respects an alignment different from 'none' in svg.preserveAspectRatio).

Note: I only changed `svg.preserveAspectRatio` in `VectorPaintEditorMorph.prototype.getSVG`. This suffices to make SVG costumes stretchable in x and y independently also in Firefox. 

Probably also the `preserveAspectRatio` in `VectorShape.prototype.imageURL` should be changed accordingly. But I was not sure when this function gets called. And I am also wondering if a call to `window.btoa` is missing for the generated SVG element in this function? (shouldn't it be `return 'data:image/svg+xml;base64,' + window.btoa(svg);` ?)