### PR TITLE
No internal canvas error if inputs to new costume are 0, just return an empty costume

### DIFF
--- a/src/threads.js
+++ b/src/threads.js
@@ -5109,6 +5109,9 @@ Process.prototype.reportNewCostume = function (pixels, width, height, name) {
     }
     width = Math.abs(Math.floor(+width));
     height = Math.abs(Math.floor(+height));
+    if (width <= 0 || height <= 0) {
+        return new Costume();
+    }
     if (!isFinite(width * height) || isNaN(width * height)) {
        throw new Error(
            'expecting a finite number\nbut getting Infinity or NaN'


### PR DESCRIPTION
The internal canvas error is not very human friendly. I think this block should do what the stretch block does: just return an empty costume.