### PR TITLE
Fixing dropdown tranlation

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -24,7 +24,6 @@
 * blocks: don't translate message names in drow-down menus
 * blocks: don't translate names in dropdowns
 * help: fixed size of MY help screen, thanks, Brian
-* byob: don't translate items in dropdowns
 * prepared release
 
 ## v5.3.1:

--- a/locale/lang-ca.js
+++ b/locale/lang-ca.js
@@ -185,7 +185,7 @@ SnapTranslator.dict.ca = {
     'translator_e-mail':
         'bernat@snap4arduino.rocks, jguille2@xtec.cat', // optional
     'last_changed':
-        '2019-11-05', // this, too, will appear in the Translators tab
+        '2019-11-06', // this, too, will appear in the Translators tab
 
     // GUI
     // control bar:
@@ -1954,6 +1954,14 @@ SnapTranslator.dict.ca = {
         'Amunt',
     'Down':
         'Avall',
+    'top':
+        'superior',
+    'bottom':
+        'inferior',
+    'left':
+        'esquerra',
+    'right':
+        'dreta',
     'This will erase your current drawing.\n':
         'El canvi d\'editor esborrarà el dibuix actual.\n',
     'Are you sure you want to continue?':

--- a/snap.html
+++ b/snap.html
@@ -12,7 +12,7 @@
         <script type="text/javascript" src="src/gui.js?version=2019-11-06"></script>
         <script type="text/javascript" src="src/paint.js?version=2019-06-27"></script>
         <script type="text/javascript" src="src/lists.js?version=2019-10-23"></script>
-        <script type="text/javascript" src="src/byob.js?version=2019-11-06"></script>
+        <script type="text/javascript" src="src/byob.js?version=2019-07-24"></script>
         <script type="text/javascript" src="src/tables.js?version=2019-06-27"></script>
         <script type="text/javascript" src="src/symbols.js?version=2019-06-27"></script>
         <script type="text/javascript" src="src/sketch.js?version=2019-10-09"></script>

--- a/src/blocks.js
+++ b/src/blocks.js
@@ -8745,7 +8745,10 @@ InputSlotMorph.prototype.menuFromDict = function (
                     (typeof choices[key] !== 'function')) {
                 menu.addMenu(
                     key,
-                    this.menuFromDict(choices[key],true));
+                    this.menuFromDict(choices[key],true),
+                    null,  // indicator
+                    true   // verbatim?
+                );
             } else {
                 menu.addItem(
                     key,

--- a/src/blocks.js
+++ b/src/blocks.js
@@ -578,7 +578,7 @@ SyntaxElementMorph.prototype.getVarNamesDict = function () {
     var block = this.parentThatIsA(BlockMorph),
         rcvr,
         tempVars = [],
-        dict = {};
+        dict;
 
     if (!block) {
         return {};
@@ -611,11 +611,9 @@ SyntaxElementMorph.prototype.getVarNamesDict = function () {
         }
     });
     if (rcvr) {
-        rcvr.variables.allNames().forEach(function (name) {
-            dict[name] = [name, false]; // don't translate
-        });
+        dict = rcvr.variables.allNamesDict();
         tempVars.forEach(function (name) {
-            dict[name] = [name, false]; // don't translate
+            dict[name] = name;
         });
         if (block.selector === 'doSetVar') {
             // add settable object attributes
@@ -8745,21 +8743,21 @@ InputSlotMorph.prototype.menuFromDict = function (
             } else if (choices[key] instanceof Object &&
                     !(choices[key] instanceof Array) &&
                     (typeof choices[key] !== 'function')) {
-                menu.addMenu(key, this.menuFromDict(choices[key], true));
-            } else if (choices[key].length === 2) { // don't translate
+                menu.addMenu(
+                    key,
+                    this.menuFromDict(choices[key],true));
+            } else {
                 menu.addItem(
                     key,
-                    choices[key][0],
+                    choices[key],
                     null, // hint
                     null, // color
                     null, // bold
                     null, // italic
                     null, // doubleClickAction
                     null, // shortcut
-                    true // verbatim - do not translate
+                    choices[key].length  === 1 || typeof choices[key] === 'function' ? false : true  // verbatim?
                 );
-            } else { // translate
-                menu.addItem(key, choices[key]);
             }
         }
     }
@@ -8779,7 +8777,7 @@ InputSlotMorph.prototype.messagesMenu = function () {
         }
     });
     allNames.forEach(function (name) {
-        dict[name] = [name, false]; // don't translate
+        dict[name] = name;
     });
     if (this.world().currentKey === 16) { // shift
         dict.__shout__go__ = ['__shout__go__'];
@@ -8816,7 +8814,7 @@ InputSlotMorph.prototype.messagesReceivedMenu = function () {
     });
     allNames.forEach(function (name) {
         if (name !== '__shout__go__') {
-            dict[name] = [name, false]; // don't translate
+            dict[name] = name;
         }
     });
     dict['~'] = null;
@@ -8855,7 +8853,7 @@ InputSlotMorph.prototype.collidablesMenu = function () {
     if (allNames.length > 0) {
         dict['~'] = null;
         allNames.forEach(function (name) {
-            dict[name] = [name, false]; // don't translate
+            dict[name] = name;
         });
     }
     return dict;
@@ -8880,7 +8878,7 @@ InputSlotMorph.prototype.locationMenu = function () {
     if (allNames.length > 0) {
         dict['~'] = null;
         allNames.forEach(function (name) {
-            dict[name] = [name, false]; // don't translate
+            dict[name] = name;
         });
     }
     return dict;
@@ -8909,7 +8907,7 @@ InputSlotMorph.prototype.distancesMenu = function () {
     if (allNames.length > 0) {
         dict['~'] = null;
         allNames.forEach(function (name) {
-            dict[name] = [name, false]; // don't translate
+            dict[name] = name;
         });
     }
     return dict;
@@ -8932,7 +8930,7 @@ InputSlotMorph.prototype.clonablesMenu = function () {
     if (allNames.length > 0) {
         dict['~'] = null;
         allNames.forEach(function (name) {
-            dict[name] = [name, false]; // don't translate
+            dict[name] = name;
         });
     }
     return dict;
@@ -8951,7 +8949,7 @@ InputSlotMorph.prototype.objectsMenu = function (includeMyself) {
     if (includeMyself) {
         dict.myself = ['myself'];
     }
-    dict[stage.name] = [stage.name, false]; // don't translate
+    dict[stage.name] = stage.name;
     stage.children.forEach(function (morph) {
         if (morph instanceof SpriteMorph && !morph.isTemporary) {
             allNames.push(morph.name);
@@ -8960,7 +8958,7 @@ InputSlotMorph.prototype.objectsMenu = function (includeMyself) {
     if (allNames.length > 0) {
         dict['~'] = null;
         allNames.forEach(function (name) {
-            dict[name] = [name, false]; // don't translate
+            dict[name] = name;
         });
     }
     return dict;
@@ -9081,7 +9079,7 @@ InputSlotMorph.prototype.attributesMenu = function () {
     if (varNames.length > 0) {
         dict['~'] = null;
         varNames.forEach(function (name) {
-            dict[name] = [name, false]; // don't translate
+            dict[name] = name;
         });
     }
     obj.allBlocks(true).forEach(function (def, i) {
@@ -9109,7 +9107,7 @@ InputSlotMorph.prototype.costumesMenu = function () {
     if (allNames.length > 0) {
         dict['~'] = null;
         allNames.forEach(function (name) {
-            dict[name] = [name, false]; // don't translate
+            dict[name] = name;
         });
     }
     return dict;
@@ -9125,7 +9123,7 @@ InputSlotMorph.prototype.soundsMenu = function () {
     });
     if (allNames.length > 0) {
         allNames.forEach(function (name) {
-            dict[name] = [name, false]; // don't translate
+            dict[name] = name;
         });
     }
     return dict;
@@ -9146,7 +9144,7 @@ InputSlotMorph.prototype.shadowedVariablesMenu = function () {
      	// inside TELL, ASK or OF or when initializing a new clone
         vars = rcvr.variables.names();
         vars.forEach(function (name) {
-            dict[name] = [name, false]; // don't translate
+            dict[name] = name;
         });
         attribs = rcvr.attributes;
         /*
@@ -9161,7 +9159,7 @@ InputSlotMorph.prototype.shadowedVariablesMenu = function () {
     	// only show shadowed vars and attributes
         vars = rcvr.inheritedVariableNames(true);
         vars.forEach(function (name) {
-            dict[name] = [name, false];
+            dict[name] = name;
         });
         attribs = rcvr.shadowedAttributes();
         /*

--- a/src/blocks.js
+++ b/src/blocks.js
@@ -8644,9 +8644,7 @@ InputSlotMorph.prototype.setContents = function (data) {
       	dta = ''; // make sure the contents text emptied
     } else { // assume dta is a localizable choice if it's a key in my choices
         cnts.isItalic = false;
-        if (!isNil(this.choices) &&
-                this.choices[dta] instanceof Array &&
-                this.choices[dta].length === 1) {
+        if (!isNil(this.choices) && this.choices[dta] instanceof Array) {
             return this.setContents(this.choices[dta]);
         }
     }

--- a/src/byob.js
+++ b/src/byob.js
@@ -108,7 +108,7 @@ BooleanSlotMorph, XML_Serializer, SnapTranslator*/
 
 // Global stuff ////////////////////////////////////////////////////////
 
-modules.byob = '2019-November-06';
+modules.byob = '2019-July-24';
 
 // Declarations
 
@@ -356,8 +356,7 @@ CustomBlockDefinition.prototype.parseChoices = function (string) {
             stack[stack.length - 1][pair[0]] = dict;
             stack.push(dict);
         } else {
-            // don't translate
-            dict[pair[0]] = [(isNil(pair[1]) ? pair[0] : pair[1]), false];
+            dict[pair[0]] = isNil(pair[1]) ? pair[0] : pair[1];
         }
     });
     return dict;

--- a/src/morphic.js
+++ b/src/morphic.js
@@ -8217,12 +8217,12 @@ MenuMorph.prototype.addItem = function (
         verbatim]);
 };
 
-MenuMorph.prototype.addMenu = function (label, aMenu, indicator) {
-    this.addPair(label, aMenu, isNil(indicator) ? '\u25ba' : indicator);
+MenuMorph.prototype.addMenu = function (label, aMenu, indicator, verbatim) {
+    this.addPair(label, aMenu, isNil(indicator) ? '\u25ba' : indicator, null, verbatim);
 };
 
-MenuMorph.prototype.addPair = function (label, action, shortcut, hint) {
-    this.addItem(label, action, hint, null, null, null, null, shortcut);
+MenuMorph.prototype.addPair = function (label, action, shortcut, hint, verbatim) {
+    this.addItem(label, action, hint, null, null, null, null, shortcut, verbatim);
 };
 
 MenuMorph.prototype.addLine = function (width) {

--- a/src/objects.js
+++ b/src/objects.js
@@ -6418,7 +6418,17 @@ SpriteMorph.prototype.chooseExemplar = function () {
             (this.exemplar ? this.exemplar.name : localize('none'))
     );
     other.forEach(function (eachSprite) {
-        menu.addItem(eachSprite.name, eachSprite);
+        menu.addItem(
+            eachSprite.name,
+            eachSprite,
+            null, // hint
+            null, // color
+            null, // bold
+            null, // italic
+            null, // doubleClickAction
+            null, // shortcut
+            true  // verbatim
+        );
     });
     menu.addLine();
     menu.addItem(localize('none'), null);


### PR DESCRIPTION
Hi Jens!

You know, #2518 comments...

It's a proposal to fix the dropdown menus and the translation behavior, using your new param (verbatim) and avoiding all those changes on values (those _[name, false]_ arrays)

I've also added four new strings to Catalan locale.

Feel free to do what was better (I can resend Catalan changes)

As I said, the most changes are undoing latest changes, and the final code is more similar to yesterday code: only the new _verbatim_ param in _morphic-addItem_ and its use inside _blocks-dropdown creation_.

Joan 