### PR TITLE
Fixing issue with 'constructor' variable name

### DIFF
--- a/src/threads.js
+++ b/src/threads.js
@@ -5922,7 +5922,7 @@ VariableFrame.prototype.silentFind = function (name) {
     answer the closest variable frame containing
     the specified variable. Otherwise return null.
 */
-    if (this.vars[name] !== undefined) {
+    if (this.vars[name] !== undefined && !(this.vars[name] instanceof Function)) {
         return this;
     }
     if (this.parentFrame) {


### PR DESCRIPTION
Fixing problem with "constructor" variable name related to #2525 