### PR TITLE
Update lang-de.js

### DIFF
--- a/locale/lang-de.js
+++ b/locale/lang-de.js
@@ -580,7 +580,7 @@ SnapTranslator.dict.de = {
     'warp %c':
         'Warp %c',
     'when I start as a clone':
-        'Wenn ich geklont werde',
+        'Wenn ich als Klon starte',
     'create a clone of %cln':
         'klone %cln',
     'a new clone of %cln':


### PR DESCRIPTION
Changed translation for "when I start as a clone".

The German translation "wenn ich geklont werde" suggests that the object being cloned executes the attached script. 

However, in reality, that code is executed by the object that is created THROUGH the cloning process, NOT the original prototype. The English block text reflects this, but the German one did not!