### PR TITLE
Catalan translation update

### DIFF
--- a/locale/lang-ca.js
+++ b/locale/lang-ca.js
@@ -6,7 +6,7 @@
 
     written by Jens Mönig
 
-    Copyright (C) 2016 by Jens Mönig
+    Copyright (C) 2020 by Jens Mönig
 
     This file is part of Snap!.
 
@@ -185,7 +185,7 @@ SnapTranslator.dict.ca = {
     'translator_e-mail':
         'bernat@snap4arduino.rocks, jguille2@xtec.cat', // optional
     'last_changed':
-        '2019-11-06', // this, too, will appear in the Translators tab
+        '2020-01-30', // this, too, will appear in the Translators tab
 
     // GUI
     // control bar:
@@ -2723,7 +2723,23 @@ SnapTranslator.dict.ca = {
         'oposat',
     '__shout__go__':
         'bandera verda premuda',
-    'new costume %l width %dim height %dim':
-        'nou vestit %l amplada %dim alçada %dim'
+    'download script':
+        'descarrega el bloc de programa',
+    'pen vectors':
+        'vectors dibuixats',
+    'Log pen vectors':
+        'Enregistra els dibuixos com a vectors',
+    'log pen vectors':
+        'enregistra els dibuixos com a vectors',
+    'uncheck to turn off\nlogging pen vectors':
+        'desmarqueu per aturar l\'enregistrament\ndels dibuixos com a vectors',
+    'check to turn on\nlogging pen vectors':
+        'marqueu per iniciar l\'enregistrament\ndels dibuixos com a vectors',
+    'there are currently no\nvectorizable pen trail segments':
+        'no hi ha cap vector dibuixat enregistrat',
+    'svg...':
+        'exporta vectors com a svg',
+    'export pen trails\nline segments as SVG':
+        'exporta els vectors dibuixats com a fitxer SVG'
 
 };

--- a/locale/lang-ca.js
+++ b/locale/lang-ca.js
@@ -2724,7 +2724,7 @@ SnapTranslator.dict.ca = {
     '__shout__go__':
         'bandera verda premuda',
     'download script':
-        'descarrega el bloc de programa',
+        'descarrega el programa',
     'pen vectors':
         'vectors dibuixats',
     'Log pen vectors':

--- a/src/locale.js
+++ b/src/locale.js
@@ -42,7 +42,7 @@
 
 /*global modules, contains*/
 
-modules.locale = '2020-January-28';
+modules.locale = '2020-January-30';
 
 // Global stuff
 
@@ -373,7 +373,7 @@ SnapTranslator.dict.ca = {
     'translator_e-mail':
         'bernat@snap4arduino.rocks, jguille2@xtec.cat',
     'last_changed':
-        '2020-01-03'
+        '2020-01-30'
 };
 
 SnapTranslator.dict.ca_VA = {


### PR DESCRIPTION
Just a Catalan translation update :)

Ping @bromagosa to check two things:
  - Is "_vectors dibuixats_" a good name for you?
  - You added `new costume %l width %dim height %dim` translation this January, but it had already been added on October. I've deleted your last one, but maybe you had done it intentionally? (my translation was (is) `'nou vestit %l d\'amplada %dim i alçada %dim'`but yours was without connectors.

Joan