### PR TITLE
Fixing color.a value at pipette feature

### DIFF
--- a/src/paint.js
+++ b/src/paint.js
@@ -512,7 +512,7 @@ PaintEditorMorph.prototype.getUserColor = function () {
             // needed for retina-display support
             return;
         }
-        color.a = 255;
+        color.a = 1;
         myself.propertiesControls.colorpicker.action(color);
     };
 


### PR DESCRIPTION
Hi!
Fixing [forum issue](https://forum.snap.berkeley.edu/t/costume-editor-crashes/1651) about costume editor crashes using the _paint bucket_ tool.

The problem is in the _pipette_ feature.
Just fixing color.a value, that has a 0-1 range (not 0-255)

Joan