### PR TITLE
Fixing Stretching to larger dimensions (Morphic2)

### DIFF
--- a/src/objects.js
+++ b/src/objects.js
@@ -9507,10 +9507,10 @@ SpriteBubbleMorph.prototype.fixLayout = function () {
 
 // Costume instance creation
 
-function Costume(canvas, name, rotationCenter) {
+function Costume(canvas, name, rotationCenter, noFit) {
     this.contents = canvas ? normalizeCanvas(canvas, true)
             : newCanvas(null, true);
-    this.shrinkToFit(this.maxExtent());
+    if (!noFit) {this.shrinkToFit(this.maxExtent()); }
     this.name = name || null;
     this.rotationCenter = rotationCenter || this.center();
     this.version = Date.now(); // for observer optimization
@@ -9699,7 +9699,8 @@ Costume.prototype.stretched = function (w, h) {
     stretched = new Costume(
         canvas,
         this.name,
-        center
+        center,
+        true
     );
     return stretched;
 };


### PR DESCRIPTION
It is #2574 rebased to Morphic2
(tested - no conflicts - fast-forward mergeable)

If this way is right, I will continue rebasing and closing old PRs

Rewriting old notes...

Hi Jens,
Related to [this issue from Snap! forum](https://forum.snap.berkeley.edu/t/bug-found-in-stretch-block/1799)

- `Costume.prototype.stretched` creates a `new Costume` and then, this runs `shrinkToFit(this.maxExtent())`. So, new stretched costumes can not bigger than Stage dimensions.
- And, in addition to this limitation, the problem is that _Costume center_ is calculated with the unlimited dimensions.
- This solution is adding a parameter _noFit_ to _Costume function_. This ensures that it does not damage any other code. In fact, only two lines at _objects.js_:

```
function Costume(canvas, name, rotationCenter, noFit ) {
...
if (!noFit) {this.shrinkToFit(this.maxExtent()); }
```
and then
```
Costume.prototype.stretched = function (w, h) {
...
    stretched = new Costume(
        canvas,
        this.name,
        center,
        true
    );
```
That's all!
Joan