### PR TITLE
Fixing dropping reporters in variadic C-shaped input slots

### DIFF
--- a/src/blocks.js
+++ b/src/blocks.js
@@ -6582,7 +6582,11 @@ ScriptsMorph.prototype.closestInput = function (reporter, hand) {
         }
         return true;
     }
-
+    //checking Target to avoid variadic C-shaped slots for reporters
+    function targetChecked(target) {
+        return (target instanceof CSlotMorph && target.parent instanceof MultiArgMorph) ? null : target;
+    }
+            
     if (this.isPreferringEmptySlots) {
         if (hand) {
             handPos = hand.position();
@@ -6601,7 +6605,7 @@ ScriptsMorph.prototype.closestInput = function (reporter, hand) {
                                 !contains(blackList, input)
             );
             if (target) {
-                return target;
+                return targetChecked(target);
             }
         }
         target = detect(
@@ -6617,7 +6621,7 @@ ScriptsMorph.prototype.closestInput = function (reporter, hand) {
                                 touchingVariadicArrowsIfAny(input)
         );
         if (target) {
-            return target;
+            return targetChecked(target);
         }
     }
 
@@ -6632,10 +6636,10 @@ ScriptsMorph.prototype.closestInput = function (reporter, hand) {
                             !contains(blackList, input)
         );
         if (target) {
-            return target;
+            return targetChecked(target);
         }
     }
-    return detect(
+    target = detect(
         all,
         input => (input !== reporter) &&
             !input.isLocked() &&
@@ -6643,6 +6647,7 @@ ScriptsMorph.prototype.closestInput = function (reporter, hand) {
                     !(input.parent instanceof PrototypeHatBlockMorph) &&
                         !contains(blackList, input)
     );
+    return targetChecked(target);
 };
 
 ScriptsMorph.prototype.closestBlock = function (comment, hand) {


### PR DESCRIPTION
Hi Jens and Brian!
This fixes #2583 

I've tried different ways, but I think this is the most coherent (robust) behavior.
Comments...
- You know CSlots are basically for command blocks (and stacks of command blocks). But in custom blocks (not in primitives) these slots allow to snap a reporter. I guess the idea is to snap a reporter/variable that have commands. Anyway, this action (snapping) change the block shape (from a CSlot to a "normal" input).

- The problem is with a "multiple input-Cshaped slot". Here, CSlotMorphs parent is not a Block... their parent is a MultiArgMorph. The problem is here.

- And we can change all the CSlotMorphs (of that MultiArgMorph) to a "reporter slot" (to fix the visual problem reported by Brian) But if the other CSlots have commands, I will have a problem loosing previous code.

Then, the solution is easy. Avoid dropping reporters into CSlots when (only when) this input is a multiple Cslots one.

Just this:
+ Single CSlot continue with current behavior, taking reporters.
![dropping1](https://user-images.githubusercontent.com/2926315/81513617-f1eced80-9329-11ea-8678-ae0f8e66644e.png)

+ And multiple Cslots do not accept reporters, but yes, we can set a reporter as the list value of all those Cslots.
![dropping2](https://user-images.githubusercontent.com/2926315/81513681-78a1ca80-932a-11ea-9dea-2b2181517575.png)

Joan
