### PR TITLE
Fixing localVars drawing on the palette

### DIFF
--- a/src/objects.js
+++ b/src/objects.js
@@ -6794,17 +6794,13 @@ SpriteMorph.prototype.hasSpriteVariable = function (varName) {
 };
 
 SpriteMorph.prototype.allLocalVariableNames = function (sorted) {
-    var exceptGlobals = this.globalVariables(),
-    	globalNames = exceptGlobals.names(),
-     	data;
+    var data;
 
     function alphabetically(x, y) {
         return x.toLowerCase() < y.toLowerCase() ? -1 : 1;
     }
 
- 	data = this.variables.allNames(exceptGlobals).filter(each =>
-		!contains(globalNames, each)
-    );
+ 	data = this.variables.names();
 	if (sorted) {
  		data.sort(alphabetically);
    }


### PR DESCRIPTION
Hi Jens,
(Just commented on other PR and on the working papers about the new make-variables lib)

Behavior:
On Snap! palette, global and sprite vars are distinguishable. Fine! But when I have the same name for a global and for a sprite var, it’s not running well.
The shape looks global but really, it is the sprite var!
And yes! It must be the local one.
I can’t have both because we can only use the sprite var on the scripting area (the closest scope). But then, we need to draw the “local sprite shape”.

Code:
Really easy fix. Function `SpriteMorph.prototype.allLocalVariableNames` was filtering (with a more complex code) and really it must report "all local variables". I keep this function because it offers the "sort" option and then, changes are minimal. Anyway, nobody else call this function so we haven't any other problem with this change.

Joan