### PR TITLE
Fixing slider position for lower values

### DIFF
--- a/src/morphic.js
+++ b/src/morphic.js
@@ -6933,18 +6933,24 @@ SliderMorph.prototype.fixLayout = function () {
         bh = Math.max(bw, Math.round(this.height() * this.ratio()));
         this.button.setExtent(new Point(bw, bh));
         posX = 1;
-        posY = Math.min(
-            Math.round((this.value - this.start) * this.unitSize()),
-            this.height() - this.button.height()
+        posY = Math.max(
+            Math.min(
+                Math.round((this.value - this.start) * this.unitSize()),
+                this.height() - this.button.height()
+            ),
+            0
         );
     } else {
         bh = this.height() - 2;
         bw  = Math.max(bh, Math.round(this.width() * this.ratio()));
         this.button.setExtent(new Point(bw, bh));
         posY = 1;
-        posX = Math.min(
-            Math.round((this.value - this.start) * this.unitSize()),
-            this.width() - this.button.width()
+        posX = Math.max(
+            Math.min(
+                Math.round((this.value - this.start) * this.unitSize()),
+                this.width() - this.button.width()
+            ),
+            0
         );
     }
     this.button.setPosition(


### PR DESCRIPTION
Hi Jens,

It's a simple fix for [this forum bug report](https://forum.snap.berkeley.edu/t/slider-bug/1978).
Maybe you want to write it different... but this is tested and point (as a helper) to the code to change.

One question aside this, would it be better to set the default "slider min" to 0?
Variables default value is (or shows) 0, and changing the watcher to a slider, we have a 0 value in "the 1 position". If you click to the sliderbuttom (without movement) that value changes to 1 (because it is in "that 1 position").
Aside this comment, maybe is "natural" a default slider from 0 to 100. Isn't it?

If you agree this, I can set this 0 in this PR... to make it simpler :)

Joan