### PR TITLE
Adding myMessages upvar

### DIFF
--- a/src/blocks.js
+++ b/src/blocks.js
@@ -1582,6 +1582,9 @@ SyntaxElementMorph.prototype.labelPart = function (spec) {
         case '%upvar':
             part = new TemplateSlotMorph('\u2191'); // up-arrow
             break;
+        case '%myMessage':
+            part = new TemplateSlotMorph('\u2709'); // envelope
+            break;
         case '%f':
             part = new FunctionSlotMorph();
             break;
@@ -5644,7 +5647,7 @@ ReporterBlockMorph.prototype.mouseClickLeft = function (pos) {
     if (this.parent instanceof BlockInputFragmentMorph) {
         return this.parent.mouseClickLeft();
     }
-    if (this.parent instanceof TemplateSlotMorph) {
+    if (this.parent instanceof TemplateSlotMorph && (this.blockSpec != '\u2709')) {
         if (this.parent.parent && this.parent.parent.parent &&
                 this.parent.parent.parent instanceof RingMorph) {
             label = "Input name";

--- a/src/blocks.js
+++ b/src/blocks.js
@@ -1585,6 +1585,9 @@ SyntaxElementMorph.prototype.labelPart = function (spec) {
         case '%myMessage':
             part = new TemplateSlotMorph('\u2709'); // envelope
             break;
+        case '%myKeyPressed':
+            part = new TemplateSlotMorph('\u2328'); // keyboard
+            break;
         case '%f':
             part = new FunctionSlotMorph();
             break;
@@ -5647,7 +5650,7 @@ ReporterBlockMorph.prototype.mouseClickLeft = function (pos) {
     if (this.parent instanceof BlockInputFragmentMorph) {
         return this.parent.mouseClickLeft();
     }
-    if (this.parent instanceof TemplateSlotMorph && (this.blockSpec != '\u2709')) {
+    if (this.parent instanceof TemplateSlotMorph) {
         if (this.parent.parent && this.parent.parent.parent &&
                 this.parent.parent.parent instanceof RingMorph) {
             label = "Input name";

--- a/src/objects.js
+++ b/src/objects.js
@@ -719,7 +719,7 @@ SpriteMorph.prototype.initBlocks = function () {
         receiveMessage: {
             type: 'hat',
             category: 'control',
-            spec: 'when I receive %msgHat'
+            spec: 'when I receive %msgHat %myMessage'
         },
         receiveCondition: {
             type: 'hat',

--- a/src/objects.js
+++ b/src/objects.js
@@ -708,7 +708,12 @@ SpriteMorph.prototype.initBlocks = function () {
         receiveKey: {
             type: 'hat',
             category: 'control',
-            spec: 'when %keyHat key pressed %myKeyPressed'
+            spec: 'when %keyHat key pressed %myUpvar'
+        },
+        pressVirtualKey: {
+            type: 'command',
+            category: 'control',
+            spec: 'press virtual key %keyHat'
         },
         receiveInteraction: {
             type: 'hat',
@@ -719,7 +724,7 @@ SpriteMorph.prototype.initBlocks = function () {
         receiveMessage: {
             type: 'hat',
             category: 'control',
-            spec: 'when I receive %msgHat %myMessage'
+            spec: 'when I receive %msgHat %myUpvar'
         },
         receiveCondition: {
             type: 'hat',
@@ -2365,6 +2370,7 @@ SpriteMorph.prototype.blockTemplates = function (category) {
 
         blocks.push(block('receiveGo'));
         blocks.push(block('receiveKey'));
+        blocks.push(block('pressVirtualKey'));
         blocks.push(block('receiveInteraction'));
         blocks.push(block('receiveCondition'));
         blocks.push(block('receiveMessage'));
@@ -8052,9 +8058,19 @@ StageMorph.prototype.fireKeyEvent = function (key) {
                         morph,
                         true // ignore running scripts, was: myself.isThreadSafe
                     ),
-                    myKeyPressed = block.inputs()[1].inputs()[0].blockSpec;
-                proc.context.outerContext.variables.addVar(myKeyPressed);
-                proc.context.outerContext.variables.setVar(myKeyPressed, evt);
+                    myUpvar = block.inputs().filter(input =>
+                        input.elementSpec == '%myUpvar')[0],
+                    myTemplate,
+                    myKey;
+                if (myUpvar) {
+                    myTemplate = myUpvar.inputs().filter(input =>
+                        input.labelString == '\u2191')[0];
+                    if (myTemplate) {
+                        myKey = myTemplate.inputs()[0].blockSpec;
+                        proc.context.outerContext.variables.addVar(myKey);
+                        proc.context.outerContext.variables.setVar(myKey, evt);
+                    }
+                }
                 procs.push(proc);
             });
         }
@@ -8365,6 +8381,7 @@ StageMorph.prototype.blockTemplates = function (category) {
 
         blocks.push(block('receiveGo'));
         blocks.push(block('receiveKey'));
+        blocks.push(block('pressVirtualKey'));
         blocks.push(block('receiveInteraction'));
         blocks.push(block('receiveCondition'));
         blocks.push(block('receiveMessage'));

--- a/src/objects.js
+++ b/src/objects.js
@@ -708,7 +708,7 @@ SpriteMorph.prototype.initBlocks = function () {
         receiveKey: {
             type: 'hat',
             category: 'control',
-            spec: 'when %keyHat key pressed'
+            spec: 'when %keyHat key pressed %myKeyPressed'
         },
         receiveInteraction: {
             type: 'hat',
@@ -8046,13 +8046,17 @@ StageMorph.prototype.fireKeyEvent = function (key) {
     }
     this.children.concat(this).forEach(morph => {
         if (isSnapObject(morph)) {
-            morph.allHatBlocksForKey(evt).forEach(block =>
-                procs.push(this.threads.startProcess(
-                    block,
-                    morph,
-                    true // ignore running scripts, was: myself.isThreadSafe
-                ))
-            );
+            morph.allHatBlocksForKey(evt).forEach(block => {
+                var proc = this.threads.startProcess(
+                        block,
+                        morph,
+                        true // ignore running scripts, was: myself.isThreadSafe
+                    ),
+                    myKeyPressed = block.inputs()[1].inputs()[0].blockSpec;
+                proc.context.outerContext.variables.addVar(myKeyPressed);
+                proc.context.outerContext.variables.setVar(myKeyPressed, evt);
+                procs.push(proc);
+            });
         }
     });
     return procs;

--- a/src/threads.js
+++ b/src/threads.js
@@ -3363,12 +3363,13 @@ Process.prototype.doBroadcast = function (message) {
             if (isSnapObject(morph)) {
                 morph.allHatBlocksFor(msg).forEach(block => {
                     var proc = stage.threads.startProcess(
-                        block,
-                        morph,
-                        stage.isThreadSafe
-                    );
-                    proc.context.outerContext.variables.addVar('\u2709');
-                    proc.context.outerContext.variables.setVar('\u2709', message);
+                            block,
+                            morph,
+                            stage.isThreadSafe
+                        ),
+                        myMessage = block.inputs()[1].inputs()[0].blockSpec;
+                    proc.context.outerContext.variables.addVar(myMessage);
+                    proc.context.outerContext.variables.setVar(myMessage, message);
                     procs.push(proc);
                 });
             }

--- a/src/threads.js
+++ b/src/threads.js
@@ -3367,9 +3367,19 @@ Process.prototype.doBroadcast = function (message) {
                             morph,
                             stage.isThreadSafe
                         ),
-                        myMessage = block.inputs()[1].inputs()[0].blockSpec;
-                    proc.context.outerContext.variables.addVar(myMessage);
-                    proc.context.outerContext.variables.setVar(myMessage, message);
+                        myUpvar = block.inputs().filter(input =>
+                            input.elementSpec == '%myUpvar')[0],
+                        myTemplate,
+                        myMessage;
+                    if (myUpvar) {
+                        myTemplate = myUpvar.inputs().filter(input =>
+                            input.labelString == '\u2191')[0];
+                        if (myTemplate) {
+                            myMessage = myTemplate.inputs()[0].blockSpec;
+                            proc.context.outerContext.variables.addVar(myMessage);
+                            proc.context.outerContext.variables.setVar(myMessage, message);
+                        }
+                    }
                     procs.push(proc);
                 });
             }
@@ -3425,6 +3435,11 @@ Process.prototype.doSend = function (message, target) {
         )
     );
 };
+
+Process.prototype.pressVirtualKey = function (key) {
+    var stage = this.homeContext.receiver.parentThatIsA(StageMorph);
+    stage.fireKeyEvent(key[0]);
+}
 
 // Process type inference
 

--- a/src/threads.js
+++ b/src/threads.js
@@ -3362,11 +3362,14 @@ Process.prototype.doBroadcast = function (message) {
         rcvrs.forEach(morph => {
             if (isSnapObject(morph)) {
                 morph.allHatBlocksFor(msg).forEach(block => {
-                    procs.push(stage.threads.startProcess(
+                    var proc = stage.threads.startProcess(
                         block,
                         morph,
                         stage.isThreadSafe
-                    ));
+                    );
+                    proc.context.outerContext.variables.addVar('\u2709');
+                    proc.context.outerContext.variables.setVar('\u2709', message);
+                    procs.push(proc);
                 });
             }
         });


### PR DESCRIPTION
Hi Jens!
Don't worry about this... Really it is not a Pull Request, it is only to show an idea (I think a PR helps us to see changes and to test it), and if this is worth it, I can remake it with the changes you would propose.

The idea is to have a message upvar. Something like this (we can change name, or visibility, or make another primitive with this...)
![blocMyMessages](https://user-images.githubusercontent.com/2926315/82557208-97defa00-9b6b-11ea-99ce-ef832af55717.png)

We know broadcasting (_doBroadcast_) search _allHatBlocksFor_ that message (or for 'any message') on all the receivers (all sprites or targeted sprites), and then, it starts a new process.
The simple idea is to pass its message to this process, as a script variable (accessible by an upvar block variable).
This allows us to use the real message (the message received) and not the "last message" (that can be another one)

A simple demo is:

![demo](https://user-images.githubusercontent.com/2926315/82559167-6b2ce180-9b6f-11ea-9472-160b2ae4117a.gif)

What do you thing about this? Is it interesting, or is it a wrong approach? If it is interesting I can make other changes and all the "routine work" for backward compatibility (translations...)
And if not, no problem, but I want to know your criteria about this, to future proposals...

Joan