### PR TITLE
typo in Catalan translation

### DIFF
--- a/locale/lang-ca.js
+++ b/locale/lang-ca.js
@@ -1164,7 +1164,7 @@ SnapTranslator.dict.ca = {
     // Project Manager
     'Untitled':
         'Sense títol',
-    'Open un Project':
+    'Open Project':
         'Obre projecte',
     '(empty)':
         '(buit)',


### PR DESCRIPTION
Just a minor typo in a source string.