### PR TITLE
Remove script type declaration

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script type="text/javascript">
+    <script>
     if (window.location) {
       window.location = 'snap.html' + window.location.hash;
     }

--- a/snap.html
+++ b/snap.html
@@ -4,28 +4,28 @@
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
         <title>Snap! Build Your Own Blocks 6.0.0 - beta -</title>
         <link rel="shortcut icon" href="src/favicon.ico">
-        <script type="text/javascript" src="src/morphic.js?version=2020-06-13"></script>
-        <script type="text/javascript" src="src/symbols.js?version=2020-06-17"></script>
-        <script type="text/javascript" src="src/widgets.js?version=2020-05-06"></script>
-        <script type="text/javascript" src="src/blocks.js?version=2020-06-15"></script>
-        <script type="text/javascript" src="src/threads.js?version=2020-06-15"></script>
-        <script type="text/javascript" src="src/objects.js?version=2020-06-14"></script>
-        <script type="text/javascript" src="src/gui.js?version=2020-06-08"></script>
-        <script type="text/javascript" src="src/paint.js?version=2020-05-17"></script>
-        <script type="text/javascript" src="src/lists.js?version=2020-05-18"></script>
-        <script type="text/javascript" src="src/byob.js?version=2020-06-08"></script>
-        <script type="text/javascript" src="src/tables.js?version=2020-05-18"></script>
-        <script type="text/javascript" src="src/sketch.js?version=2020-04-15"></script>
-        <script type="text/javascript" src="src/video.js?version=2019-06-27"></script>
-        <script type="text/javascript" src="src/maps.js?version=2020-03-25"></script>
-        <script type="text/javascript" src="src/xml.js?version=2020-04-27"></script>
-        <script type="text/javascript" src="src/store.js?version=2020-05-18"></script>
-        <script type="text/javascript" src="src/locale.js?version=2020-06-08"></script>
-        <script type="text/javascript" src="src/cloud.js?version=2020-05-17"></script>
-        <script type="text/javascript" src="src/api.js?version=2020-04-27"></script>
-        <script type="text/javascript" src="src/sha512.js?version=2019-06-27"></script>
-        <script type="text/javascript" src="src/FileSaver.min.js?version=2019-06-27"></script>
-        <script type="text/javascript">
+        <script src="src/morphic.js?version=2020-06-13"></script>
+        <script src="src/symbols.js?version=2020-06-17"></script>
+        <script src="src/widgets.js?version=2020-05-06"></script>
+        <script src="src/blocks.js?version=2020-06-15"></script>
+        <script src="src/threads.js?version=2020-06-15"></script>
+        <script src="src/objects.js?version=2020-06-14"></script>
+        <script src="src/gui.js?version=2020-06-08"></script>
+        <script src="src/paint.js?version=2020-05-17"></script>
+        <script src="src/lists.js?version=2020-05-18"></script>
+        <script src="src/byob.js?version=2020-06-08"></script>
+        <script src="src/tables.js?version=2020-05-18"></script>
+        <script src="src/sketch.js?version=2020-04-15"></script>
+        <script src="src/video.js?version=2019-06-27"></script>
+        <script src="src/maps.js?version=2020-03-25"></script>
+        <script src="src/xml.js?version=2020-04-27"></script>
+        <script src="src/store.js?version=2020-05-18"></script>
+        <script src="src/locale.js?version=2020-06-08"></script>
+        <script src="src/cloud.js?version=2020-05-17"></script>
+        <script src="src/api.js?version=2020-04-27"></script>
+        <script src="src/sha512.js?version=2019-06-27"></script>
+        <script src="src/FileSaver.min.js?version=2019-06-27"></script>
+        <script>
             var world;
             window.onload = function () {
                 world = new WorldMorph(document.getElementById('world'));


### PR DESCRIPTION
### Changes

Removes script type declaration from index.html and snap.html.

### Cause of Changes

The default scripting language for browsers is JavaScript. So, keeping declarations is unnecessary and a waste of storage.

### Test Coverage

Locally tested by editing the files with Notepad and running them on my browser (Firefox) afterwards.
