### PR TITLE
Add noscript tag with instructions on how to enable JavaScript

### DIFF
--- a/snap.html
+++ b/snap.html
@@ -40,6 +40,6 @@
     </head>
     <body style="margin: 0;">
         <canvas id="world" tabindex="1" style="position: absolute;"></canvas>
-	<noscript><p>JavaScript is required to properly display this page. Please enable JavaScript in order to continue. You can do this by clicking the lock icon on your browser. Please take a look <a href="https://www.google.com/search?q=how+to+enable+javascript">here</a> if you are unsure about how to enable JavaScript.</p></noscript>
+	<noscript><p>JavaScript is required to display this page properly. Please enable JavaScript in order to continue. You can do this by clicking the lock icon on your browser. Please take a look <a href="https://www.google.com/search?q=how+to+enable+javascript">here</a> if you are unsure about how to enable JavaScript.</p></noscript>
     </body>
 </html>

--- a/snap.html
+++ b/snap.html
@@ -40,5 +40,6 @@
     </head>
     <body style="margin: 0;">
         <canvas id="world" tabindex="1" style="position: absolute;"></canvas>
+	<noscript><p>JavaScript is required to properly display this page. Please enable JavaScript in order to continue. You can do this by clicking the lock icon on your browser. Please take a look <a href="https://www.google.com/search?q=how+to+enable+javascript">here</a> if you are unsure about how to enable JavaScript.</p></noscript>
     </body>
 </html>


### PR DESCRIPTION
### Changes

Adds noscript tag with instructions on how to enable JavaScript.

### Cause of Changes

Users who have disabled JavaScript mistakenly or intentionally are unable to see anything currently. They might think that it is a Snap<i>!</i> bug, which it is not. Also, young users may not know how to enable JavaScript.

### Test Coverage

Locally tested by editing the files with Notepad and running them on my browser (Chrome) afterwards, and I can assure you that they do not appear when JavaScript is enabled.
