### PR TITLE
Remove English category and section names from Bengali translation

### DIFF
--- a/locale/lang-bn.js
+++ b/locale/lang-bn.js
@@ -184,7 +184,7 @@ SnapTranslator.dict.bn = {
     'translator_e-mail':
         'mokter@gmail.com', // optional
     'last_changed':
-        '2014-07-02', // this, too, will appear in the Translators tab
+        '2020-06-25', // this, too, will appear in the Translators tab
 
 
     // GUI
@@ -196,23 +196,23 @@ SnapTranslator.dict.bn = {
 
     // categories:
     'Motion':
-        'গতি (Motion)',
+        'গতি',
     'Looks':
-        'সৌন্দর্য (Looks)',
+        'সৌন্দর্য',
     'Sound':
-        'শব্দ (Sound)',
+        'শব্দ',
     'Pen':
-        'লেখনী (Pen)',
+        'লেখনী',
     'Control':
-        'নিয়ন্ত্রণ (Control)',
+        'নিয়ন্ত্রণ',
     'Sensing':
-        'অনুভূতি (Sensing)',
+        'অনুভূতি',
     'Operators':
-        'চালক (Operators)',
+        'চালক',
     'Variables':
-        'চলক (Variables)',
+        'চলক',
     'Lists':
-        'তালিকা (Lists)',
+        'তালিকা',
     'Other':
         'অন্যান্য',
 
@@ -222,11 +222,11 @@ SnapTranslator.dict.bn = {
 
     // tabs:
     'Scripts':
-        'প্রোগ্রাম স্ক্রিপ্ট (Scripts)',
+        'প্রোগ্রাম স্ক্রিপ্ট',
     'Costumes':
-        'পরিচ্ছদ (Costumes)',
+        'পরিচ্ছদ',
     'Sounds':
-        'শব্দমালা (Sounds)',
+        'শব্দমালা',
 
     // names:
     'Sprite':


### PR DESCRIPTION
### Changes

Removes English category and section names from Bengali translation (and obviously updates the last changed date!).

### Cause of Changes

The English category names are unnecessary. They may also make it confusing for children. Here is how it currently looks like-
<img width="461" alt="Annotation 2020-06-25 173107" src="https://user-images.githubusercontent.com/61620631/85712810-83fa5b00-b70a-11ea-97ab-f575d23e7ed6.png">

### Test Coverage

Unnecessary but locally tested by editing the file with Notepad and then opening Snap<i>!</i> on my browser (Firefox).

### Extra Notes

The translation is not updated yet (, @jguille2).

