### PR TITLE
Remove wrong reference for translators

### DIFF
--- a/src/locale.js
+++ b/src/locale.js
@@ -30,12 +30,7 @@
 
         lang-de.js
 
-    or to the separate file
-
-        translating Snap.txt
-
-    (same contents) if you would like to contribute.
-
+    if you would like to contribute.
 */
 
 // Global settings /////////////////////////////////////////////////////


### PR DESCRIPTION
### Changes

Removes wrong reference for translators.

### Cause of Changes

There is currently no such file called "translating Snap.txt".