### PR TITLE
Fixing clearCanvas action

### DIFF
--- a/src/paint.js
+++ b/src/paint.js
@@ -719,6 +719,7 @@ PaintCanvasMorph.prototype.centermerge = function (a, b) {
 
 PaintCanvasMorph.prototype.clearCanvas = function () {
     this.buildContents();
+    this.drawNew();
     this.changed();
 };
 


### PR DESCRIPTION
Hi Jens!
From this forum issue (https://forum.snap.berkeley.edu/t/paint-editor-clear-in-bitmap-mode-does-not-work-in-vector-mode-it-works/2311)

Yes, I reproduce this issue.

I've only restore the "drawNew()" line to update the cavas (to the just done _clear_ action). To check if this is right, I point the commit where this line was deleted (https://github.com/jmoenig/Snap/commit/0d053d3ff77d245477badcf7b7410576bb025855#diff-4f0be712c72e1f804a9ff53973e77a82).

It is checked. Without the "drawNew" the clear action is done, but the canvas is not updated.

Joan

