### PR TITLE
fixing issues (constraining and switching) on PaintEditor

### DIFF
--- a/src/objects.js
+++ b/src/objects.js
@@ -9973,7 +9973,8 @@ SVG_Costume.prototype.edit = function (
     oncancel,
     onsubmit
 ) {
-    var editor = new VectorPaintEditorMorph();
+    var editor = new VectorPaintEditorMorph(),
+        myself = this;
 
     editor.oncancel = oncancel || nop;
     editor.openIn(
@@ -9981,14 +9982,14 @@ SVG_Costume.prototype.edit = function (
         isnew ? newCanvas(StageMorph.prototype.dimensions) : this.contents,
         isnew ? new Point(240, 180) : this.rotationCenter,
         (img, rc, shapes) => {
-            this.contents = img;
-            this.rotationCenter = rc;
-            this.shapes = shapes;
-            this.version = Date.now();
+            myself.contents = img;
+            myself.rotationCenter = rc;
+            myself.shapes = shapes;
+            myself.version = Date.now();
             aWorld.changed();
             if (anIDE) {
-                if (isnew) {anIDE.currentSprite.addCostume(this); }
-                anIDE.currentSprite.wearCostume(this);
+                if (isnew) {anIDE.currentSprite.addCostume(myself); }
+                anIDE.currentSprite.wearCostume(myself);
                 anIDE.hasChangedMedia = true;
             }
             (onsubmit || nop)();

--- a/src/paint.js
+++ b/src/paint.js
@@ -241,10 +241,9 @@ PaintEditorMorph.prototype.buildEdits = function () {
                     'This will erase your current drawing.\n' +
                     'Are you sure you want to continue?',
                     'Switch to vector editor?',
-                    function () {
-                        myself.switchToVector();
-                    },
-                    nop
+                    () => {
+                        setTimeout(() => {myself.switchToVector()});
+                    }
                 );
             } else {
                 myself.switchToVector();
@@ -283,21 +282,21 @@ PaintEditorMorph.prototype.openIn = function (
     callback,
     anIDE
 ) {
+    var myself = this;
     // Open the editor in a world with an optional image to edit
     this.oldim = oldim;
     this.callback = callback || nop;
     this.ide = anIDE;
 
     this.processKeyUp = function () {
-        this.shift = false;
-        this.propertiesControls.constrain.refresh();
+        myself.shift = false;
+        myself.propertiesControls.constrain.refresh();
     };
 
     this.processKeyDown = function () {
-        this.shift = this.world().currentKey === 16;
-        this.propertiesControls.constrain.refresh();
+        myself.shift = myself.world().currentKey === 16;
+        myself.propertiesControls.constrain.refresh();
     };
-
     //merge oldim:
     if (this.oldim) {
         this.paper.automaticCrosshairs = isNil(oldrc);
@@ -349,16 +348,12 @@ PaintEditorMorph.prototype.cancel = function () {
 };
 
 PaintEditorMorph.prototype.switchToVector = function () {
-    var myself = this;
+
     this.object = new SVG_Costume(new Image(), '', new Point(0,0));
     this.object.edit(
         this.world(),
         this.ide,
-        true,
-        this.oncancel,
-        function() {
-            myself.ide.currentSprite.changed();
-        }
+        true
     );
 };
 

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -1584,7 +1584,6 @@ DialogBoxMorph.prototype.askYesNo = function (
     this.addButton('ok', 'Yes');
     this.addButton('cancel', 'No');
     this.fixLayout();
-    this.fixLayout();
     this.popUp(world);
 };
 


### PR DESCRIPTION
Hi Jens (@jmoenig),

This is about [that forum bug report about PaintEditors constrain feature](https://forum.snap.berkeley.edu/t/paint-editor-shift-does-not-constrain/2310/2).
This is tested, but I want to test a little more (because there are quite a few changes and a lot of actions to test (switching between editors, painting, saving, using tools, keyboard events...). Anyway, this PR helps us to share these changes and check if those ways are right...
A summary:
- To allow constraining with the _shift_ key, on "direct" _VectorPaintEditor_ we have to use `currentKey` and not `event.shiftKey`. It is the same behavior than _PaintEditor_.
 ```
-       this.shift = event.shiftKey;
-        this.ctrl = event.ctrlKey;
+        myself.shift = myself.world().currentKey === 16;
+        myself.ctrl = event.ctrlKey;
```
- To allow constraining with the _shift_ key after switching between editors (bitmap <-> vector) we have to call the "switcher" asynchronously, because the _confirm dialog_ is capturing the _keyboard listener_. So, we have to run _openIn_ functions after closing those dialogs.
on paint.js
```
            if (myself.paper.undoBuffer.length > 0) {
                myself.ide.confirm(
                    'This will erase your current drawing.\n' +
                    'Are you sure you want to continue?',
                    'Switch to vector editor?',
                    () => {
                        setTimeout(() => {myself.switchToVector()});
                    }
                );
            } else {
                myself.switchToVector();
            }
```
and on sketch.js
```
                if (myself.shapes.length > 0) {
                    myself.ide.confirm(
                        'This will convert your vector objects into\n' +
                        'bitmaps, and you will not be able to convert\n' +
                        'them back into vector drawings.\n' +
                        'Are you sure you want to continue?',
                        'Convert to bitmap?',
                        () => {
                            setTimeout(() => {myself.convertToBitmap()});
                        }
                    );
                } else {
                    myself.convertToBitmap();
                }
```

- To allow saving after switching editors several times (bitmap -> vector -> bitmap...) we have to add the "onsubmit action" to _convertToBitmap_ function. The reason is we are not creating a new costume (we are using the one converted from our vectorEditor) but maybe we are not editing a previous costume from our wardrobe.
The result of this is:
  + As current version, if we edit a svg costume, changing it to bitmap. Our editor will create a new costume (not deleting the previous svg costume). This is debatable.... but now (and in v5 too) is doing nothing... and it's the same occurs when we change a costume from bitmap to svg (this creates a new costume without deleting previous one).
  + Creating a new costume, and switching from vector to bitmap, saving is running (not now in current version).

- And the other changes are only typos and little bugs without errors (_this_ to _myself, functions parameters, changes to _arrow functions_ format...)

I want to test more (to avoid possible errors) and I will confirm here...

Joan