### PR TITLE
Remove shortcut from "shortcut icon"

### DIFF
--- a/snap.html
+++ b/snap.html
@@ -3,7 +3,7 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
         <title>Snap! Build Your Own Blocks 6.0.1 - dev -</title>
-        <link rel="shortcut icon" href="src/favicon.ico">
+        <link rel="icon" href="src/favicon.ico">
         <script src="src/morphic.js?version=2020-07-16"></script>
         <script src="src/symbols.js?version=2020-07-01"></script>
         <script src="src/widgets.js?version=2020-07-13"></script>


### PR DESCRIPTION
### Resolves

Resolves #2644.

### Changes

Removes shortcut from <link rel="shortcut icon" href="src/favicon.ico">.

### Cause of Changes

Read #2644.