### PR TITLE
fixed green flag size in embed mode

### DIFF
--- a/src/gui.js
+++ b/src/gui.js
@@ -1923,7 +1923,7 @@ IDE_Morph.prototype.fixLayout = function (situation) {
                         this.width(), this.height())) / 5;
             flag.setWidth(flag.size);
             flag.setHeight(flag.size);
-            this.embedPlayButton.size = flag.size * 1.6;
+            this.embedPlayButton.size = flag.size * 2;
             this.embedPlayButton.setWidth(this.embedPlayButton.size);
             this.embedPlayButton.setHeight(this.embedPlayButton.size);
             if (this.embedOverlay) {


### PR DESCRIPTION
It now looks like it did before v6:

![imatge](https://user-images.githubusercontent.com/1016697/89395163-3f041400-d70d-11ea-9474-5b2b30d213bb.png)

This is how it looks before the fix:

![imatge](https://user-images.githubusercontent.com/1016697/89395241-58a55b80-d70d-11ea-952d-00c4245f2fdd.png)
