### PR TITLE
Add "add comment" option to the block context menu

### DIFF
--- a/src/blocks.js
+++ b/src/blocks.js
@@ -3024,6 +3024,35 @@ BlockMorph.prototype.userMenu = function () {
         "delete",
         'userDestroy'
     );
+    if (isNil(this.comment)) {
+        menu.addItem(
+            "add comment",
+            () => {
+                var comment = new CommentMorph();
+                this.comment = comment;
+                comment.block = this;
+                comment.layoutChanged();
+
+                // Simulate drag/drop for better undo/redo behavior
+                var scripts = this.parentThatIsA(ScriptsMorph),
+                    ide = this.parentThatIsA(IDE_Morph),
+                    blockEditor = this.parentThatIsA(BlockEditorMorph);
+                if (!ide && blockEditor) {
+                    ide = blockEditor.target.parentThatIsA(IDE_Morph);
+                }
+                if (ide) {
+                    world.hand.grabOrigin = {
+                        origin: ide.palette,
+                        position: ide.palette.center()
+                    };
+                }
+                scripts.clearDropInfo();
+                scripts.lastDropTarget = { element: this };
+                scripts.lastDroppedBlock = comment;
+                scripts.recordDrop(world.hand.grabOrigin);
+            }
+        );
+    }
     menu.addItem(
         "script pic...",
         () => {


### PR DESCRIPTION
![block-add-comment](https://user-images.githubusercontent.com/671815/94209047-52279a80-fe99-11ea-9a4f-cf48cc01f203.gif)

Just one data point but I think I literally didn't realize you could leave comments for the duration of my TEALS class last year.  I think there's an argument for converting the script area context menu into some sort of toolbar so its actions are more discoverable, but in the meantime I think we can at least make commenting more discoverable by adding it as an option on the context menu for blocks (which I open all the time) vs. just an option on context menu for the script area (which I never really think to open).  Hopefully will lead students to leave more comments 😄 

Couldn't figure out a way to plug into the undo/redo history than just by simulating a drag-drop, happy to change if there's a better way.  Tested out this method and it has the same behavior as adding a comment through the script area context menu
![block-add-comment-undo-redo](https://user-images.githubusercontent.com/671815/94209523-82236d80-fe9a-11ea-94fe-117eeff10909.gif)

Also couldn't make sense of the talk of "changesets" in the contributing guidelines and didn't see other PRs doing anything like that but happy to submit in a different format if necessary.

Rob