### PR TITLE
Fixing (bitmap)costume fitting

### DIFF
--- a/src/objects.js
+++ b/src/objects.js
@@ -9879,8 +9879,27 @@ Costume.prototype.editRotationPointOnly = function (aWorld) {
 // Costume thumbnail
 
 Costume.prototype.shrinkToFit = function (extentPoint) {
+    var scale,
+        fittedExtentPoint,
+        fittedCanvas,
+        ctx;
     if (extentPoint.x < this.width() || (extentPoint.y < this.height())) {
-        this.contents = this.thumbnail(extentPoint);
+        scale = Math.min(
+            (extentPoint.x / this.width()),
+            (extentPoint.y / this.height())
+        );
+        fittedExtentPoint = new Point(this.width() * scale, this.height() * scale);
+        fittedCanvas = newCanvas(fittedExtentPoint, true);
+        ctx = fittedCanvas.getContext('2d');
+        ctx.save();
+        ctx.scale(scale, scale);
+        ctx.drawImage(
+            this.contents,
+            0,
+            0
+        );
+        ctx.restore();
+        this.contents = fittedCanvas;
     }
 };
 


### PR DESCRIPTION
Hi!
## Issue:
- Bitmap costumes larger than stage are fitted to the stage dimensions.
- This is running Ok (the image is fine), but _costume extent_ info is wrong. It shows stage extents. Then width or height is wrong (depending on the fitting).
- And this causes different problems."width/height" of costume reporter is wrong,  and also the "pixel of costume" is not fine.

## Cause:
- `shrinkToFit` function uses `thumbnail` execution
- `thumbnail` returns a fine fitted image, but in a Canvas with the dimensions of their container (where the costume is fitted)
- This is fine for `thumbnail` because images are centered (for example inside the Wardrobe (`CostumeIconMorph`) or for `SpeechBubbleMorph`)

## Proposal
This PR writes its own code for `shrinkToFit` to scale (fit) images in a proportional canvas.

Note: SVGCostumes are not fitted. I'll submit a new PR with a proposal to do it (to get the same behavior)

Thanks,
Joan