### PR TITLE
Fixing svg loading

### DIFF
--- a/src/gui.js
+++ b/src/gui.js
@@ -2145,27 +2145,34 @@ IDE_Morph.prototype.droppedSVG = function (anImage, name) {
         headerLenght = anImage.src.search('base64') + 7, // usually 26 from "data:image/svg+xml;base64,"
         svgStrEncoded = anImage.src.substring(headerLenght),
         svgObj = new DOMParser().parseFromString(atob(svgStrEncoded), "image/svg+xml").firstElementChild;
+
     name = name.split('.')[0];
 
-    // check svg content and size it if necessary before loading
+    // check svg 'width' and 'height' attributes and set them if needed
 
-    if (svgObj.attributes.getNamedItem("viewBox")) { // viewBox attribute is mandatory
-        // width and height are required
-        if (!svgObj.attributes.getNamedItem("width") ||
-                !svgObj.attributes.getNamedItem("height")) {
+    if (svgObj.attributes.getNamedItem("width") &&
+            svgObj.attributes.getNamedItem("height")) {
+        this.loadSVG(anImage, name);
+    } else {
+        // setting HTMLImageElement default values
+        w = '300';
+        h = '150';
+        // changing default values if viewBox attribute is set
+        if (svgObj.attributes.getNamedItem("viewBox")) {
             viewBox = svgObj.attributes.getNamedItem('viewBox').value;
-            w = Math.ceil(viewBox.split(' ')[2]);
-            h = Math.ceil(viewBox.split(' ')[3]);
-            svgNormalized = new Image(w, h);
-            svgObj.setAttribute('width', w);
-            svgObj.setAttribute('height', h);
-            svgNormalized.src = 'data:image/svg+xml;base64,' +
-                btoa(new XMLSerializer().serializeToString(svgObj));
-            myself = this;
-            svgNormalized.onload = function () { myself.loadSVG(svgNormalized, name); }
-        } else {
-            this.loadSVG(anImage, name);
-        }
+            viewBox = viewBox.split(/[ ,]/).filter(item => item);
+            if (viewBox.length == 4) {
+                w = Math.ceil(viewBox[2]);
+                h = Math.ceil(viewBox[3]);
+            }
+         }
+         svgNormalized = new Image(w, h);
+         svgObj.setAttribute('width', w);
+         svgObj.setAttribute('height', h);
+         svgNormalized.src = 'data:image/svg+xml;base64,' +
+             btoa(new XMLSerializer().serializeToString(svgObj));
+         myself = this;
+         svgNormalized.onload = function () { myself.loadSVG(svgNormalized, name); }
     }
 };
 


### PR DESCRIPTION
Hi!

This can be the first step to improve svg management (next steps would be "fitting large costumes" and a "svg stretching" feature).

## Current issue
- Many _svg_ images are badly uploaded in Snap! The reason is they (I see this in many free svg images) have not _width_ and _height_ attributes. Image viewers and browsers load and show them properly, with a default size, but our management of the HTMLImageElement (for the SVG_Costumes) has problems.
- In Firefox, this results in "empty" costumes loaded.
- In Chrome this seems to go better (not empty) but the result is not fine. We get cropped images (depends on the proportions), with smaller thumbnails and, if we play with the "size" property,  we will see a totally wrong behavior.

## Testing this issue

[svgTests.zip](https://github.com/jmoenig/Snap/files/5609967/svgTests.zip)

Two svg images to test.

- The original one (it has not _width_ and _height_ attributes)
- The sized sample (is the original, adding these attributes with a text editor)

## This PR proposal
- It checks svg images (from importing or dropping svg files).
- _viewBox_ attribute is mandatory. Without it, the image is not loaded (no errors)
- If _width_ and _height_ attributes are missing, it writes them, using the "viewBox" values.
- Yes, if "viewBox" has large values, that image will have a large size. But if this PR is accepted, "fitting behavior" will be added (like bitmapCostumes does) later.
- Note that this _checker_ is made in two functions with an asynchronous process (an _onload_ event). This is required to draw the costume thumbnail in that creation moment (it would be updated later without problems, but not in the first moment). The reason is the _drawImage_ function (to draw that thumbnail) needs a _loaded_ ImageElement. And if is not completely loaded, it draws an empty image.

Joan