### PR TITLE
compiled multimap

### DIFF
--- a/src/blocks.js
+++ b/src/blocks.js
@@ -2839,6 +2839,7 @@ BlockMorph.prototype.userMenu = function () {
     ) {
         alternatives = {
             reportMap : 'reportAtomicMap',
+			reportMap : 'reportAtomicMultimap',
             reportKeep : 'reportAtomicKeep',
             reportFindFirst: 'reportAtomicFindFirst',
             reportCombine : 'reportAtomicCombine'
@@ -2853,6 +2854,7 @@ BlockMorph.prototype.userMenu = function () {
         contains(
             [
                 'reportAtomicMap',
+				'reportAtomicMultimap',				
                 'reportAtomicKeep',
                 'reportAtomicFindFirst',
                 'reportAtomicCombine'
@@ -2862,6 +2864,7 @@ BlockMorph.prototype.userMenu = function () {
     ) {
         alternatives = {
             reportAtomicMap : 'reportMap',
+			reportAtomicMultimap : 'reportMap',
             reportAtomicKeep : 'reportKeep',
             reportAtomicFindFirst: 'reportFindFirst',
             reportAtomicCombine : 'reportCombine'
@@ -11714,6 +11717,7 @@ MultiArgMorph.prototype.is3ArgRingInHOF = function () {
                     [
                         'reportMap',
                         'reportAtomicMap',
+						'reportAtomicMultimap',
                         'reportKeep',
                         'reportAtomicKeep',
                         'reportFindFirst',

--- a/src/objects.js
+++ b/src/objects.js
@@ -1381,6 +1381,12 @@ SpriteMorph.prototype.initBlocks = function () {
             category: 'lists',
             spec: '%blitz map %repRing over %l'
         },
+        reportAtomicMultimap: {
+            dev: true, // not shown in palette, only accessible via relabelling
+            type: 'reporter',
+            category: 'lists',
+            spec: '%blitz map %repRing over %lists'
+        },
         reportKeep: {
             type: 'reporter',
             category: 'lists',


### PR DESCRIPTION
This PR makes the compiled version of MAP variadic.  The expected use case is that the function input's ring does not have formal parameters, and  corresponding items of the input lists fill the empty slots in the ringed expression.

For compatibility, if the ring is given formal parameters, then the first one ("value") is bound to a list of the corresponding items of the input lists.

<img width="761" alt="Google Chrome001" src="https://user-images.githubusercontent.com/3885074/101329809-b9ad7f00-3826-11eb-94f3-575e569710e7.png">

PS I'm hoping this will speed up the APL library quite a lot.
