### PR TITLE
add typecheck to doRepeat command, fixes #2809

### DIFF
--- a/src/threads.js
+++ b/src/threads.js
@@ -2535,7 +2535,8 @@ Process.prototype.doRepeat = function (counter, body) {
         outer = this.context.outerContext, // for tail call elimination
         isCustomBlock = this.context.isCustomBlock;
 
-    if (counter < 1) { // was '=== 0', which caused infinite loops on non-ints
+    if (isNaN(counter) || counter < 1) { 
+	// was '=== 0', which caused infinite loops on non-ints
         return null;
     }
     this.popContext();


### PR DESCRIPTION
This PR fixes the isse 2809 (#2809).
It just checks if the variable used in repeat is a number.

This time without having prettier "prettify" the whole file. Sorry, Jens :-)