### PR TITLE
fix negative color effect in objects.js

### DIFF
--- a/src/objects.js
+++ b/src/objects.js
@@ -5113,7 +5113,7 @@ SpriteMorph.prototype.applyGraphicsEffects = function (canvas) {
             }
             v = max / 255;
 
-            h = (h + hueShift * 360 / 200) % 360;
+            h = (((h + hueShift * 360 / 200) % 360)+360)%360;
             s = Math.max(0, Math.min(s + saturationShift / 100, 1));
             v = Math.max(0, Math.min(v + brightnessShift / 100, 1));
 


### PR DESCRIPTION
In JS, foo%360 gives a negative remainder if the dividend is negative.  This one-line change from developer.mozilla.org computes the correct modulo.
