### PR TITLE
CursorMorph renders with same color as its target

### DIFF
--- a/src/morphic.js
+++ b/src/morphic.js
@@ -5513,6 +5513,7 @@ CursorMorph.prototype.init = function (aStringOrTextMorph, aTextarea) {
     // override inherited defaults
     ls = fontHeight(this.target.fontSize);
     this.setExtent(new Point(Math.max(Math.floor(ls / 20), 1), ls));
+    this.color = this.target.color;
     
     if (this.target instanceof TextMorph &&
             (this.target.alignment !== 'left')) {
@@ -5523,6 +5524,12 @@ CursorMorph.prototype.init = function (aStringOrTextMorph, aTextarea) {
     this.gotoSlot(this.slot);
     this.updateTextAreaPosition();
     this.syncTextareaSelectionWith(this.target);
+};
+
+// CursorMorph drawing:
+
+CursorMorph.prototype.getRenderColor = function () {
+    return this.target.getRenderColor();
 };
 
 // CursorMorph event handling


### PR DESCRIPTION
Simple fix to make the text cursor render with the same color as the text on its target element. (In current Snap, it always renders black.)

I encountered this when trying out the "fade blocks" feature; I made them dark enough that the text in input slots turned white (to personal taste, 80%). Then I typed in an input, but found the cursor was nearly illegible against the relatively dark background:

![A simple script with the cursor inside a "say" block's text field. It's a small black line, hard to see against the dim purple background.](https://user-images.githubusercontent.com/9948030/118400796-87a41280-b639-11eb-9716-500ce6a8a300.png)

With this fix, the cursor is much brighter and easier to read, just like intended for the actual text:

![The same script with the cursor in the sample; now, it's much easier to see and locate.](https://user-images.githubusercontent.com/9948030/118400840-c4700980-b639-11eb-8971-7ce69d196c6a.png)

Since this uses the same color as the text (which [draws using the same method](https://github.com/jmoenig/Snap/blob/21a681fc3cf89194164ddf470a4f958e9d57d656/src/morphic.js#L8588)), this should always produce an equally visible cursor—e.g, in other text inputs which remain black on white, the cursor respects this:

![The cursor inside a sprite's name field. Like the text, the cursor is black against a white background.](https://user-images.githubusercontent.com/9948030/118400975-3ea08e00-b63a-11eb-9805-d67bf04d1611.png)

(PS: though offtopic, I love that Snap! uses the font I've customized in the browser as my default sans-serif!)