### PR TITLE
Position cursor at selectionStart when the selection is backwards

### DIFF
--- a/src/morphic.js
+++ b/src/morphic.js
@@ -5608,23 +5608,27 @@ CursorMorph.prototype.processKeyDown = function (event) {
 CursorMorph.prototype.processKeyUp = function (event) {
     // handle selection change and cursor position change.
     var textarea = this.textarea,
-        target = this.target;
+        target = this.target,
+        positionSlot;
 
     if (textarea.selectionStart === textarea.selectionEnd) {
         target.startMark = null;
         target.endMark = null;
+        positionSlot = textarea.selectionStart;
     } else {
         if (textarea.selectionDirection === 'backward') {
             target.startMark = textarea.selectionEnd;
             target.endMark = textarea.selectionStart;
+            positionSlot = textarea.selectionStart;
         } else {
             target.startMark = textarea.selectionStart;
             target.endMark = textarea.selectionEnd;
+            positionSlot = textarea.selectionEnd;
         }
     }
     target.fixLayout();
     target.rerender();
-    this.gotoSlot(textarea.selectionEnd);
+    this.gotoSlot(positionSlot);
 };
 
 CursorMorph.prototype.processInput = function (event) {


### PR DESCRIPTION
Currently, when making a selection via the arrow keys, if the selection is "backwards" (e.g. moving left from the initial point) the corresponding CursorMorph will place itself at the initial point of the selection, rather than the actual textarea cursor being moved with the keyboard.

For example, say a cursor is placed as below:

![A "say" block with the text "Isn't this exciting?". The cursor is placed right after "this".](https://user-images.githubusercontent.com/9948030/118402164-1ebf9900-b63f-11eb-8295-b5cd3a0e8a77.png)

Then we move it left, to select the previous word:

![The same block; a selection is made around the word "this", with the cursor remaining at the end, after "this".](https://user-images.githubusercontent.com/9948030/118402087-d1432c00-b63e-11eb-9fff-ad430b7c00fc.png)

It's a bit tricky to see because the cursor doesn't contrast much with the selection mark color, but the cursor visually remains where it started, after "this".

In current behavior, the cursor is always moved to `selectionEnd`. However, browsers\* declare `selectionEnd` to be the later index, regardless of the stated `selectionDirection`. So with this PR, when moving backwards, we instead position the cursor at `selectionStart`, fixing a case where the cursor doesn't visually correspond to what's actually being moved.

\* I've tested this in Firefox and Chromium on Linux (debian), and behavior seems consistent there. This note from [sec 4.10.19 of HTML5's living standard](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#textFieldSelection) seems relevant:

> On Windows, the direction indicates the position of the caret relative to the selection: a "forward" selection has the caret at the end of the selection and a "backward" selection has the caret at the start of the selection. Windows has no "none" direction.
>
> On Mac, the direction indicates which end of the selection is affected when the user adjusts the size of the selection using the arrow keys with the Shift modifier: the "forward" direction means the end of the selection is modified, and the "backward" direction means the start of the selection is modified. The "none" direction is the default on Mac, it indicates that no particular direction has yet been selected. The user sets the direction implicitly when first adjusting the selection, based on which directional arrow key was used.

I don't have a Windows system to test on at the moment. I think backwards selection (via keyboard) handles input the same way there; it looks like the only difference is in whether or not it shows the cursor. I'd need someone else to verify that and test this PR, though!

~~Note that browsers don't actually typically show where the cursor is positioned while making a selection, at least on Linux and macOS (to my recollection).~~ (**Edit:** as the above note indicates, it looks like the cursor does show on Windows.) This could probably be matched in morphic.js pretty easily, though altogether hiding the cursor at any point strikes me as a bit of an accessibility issue in the first place.