### PR TITLE
Consider empty rings empty slots

### DIFF
--- a/src/blocks.js
+++ b/src/blocks.js
@@ -6678,6 +6678,10 @@ RingMorph.prototype.dataType = function () {
     }
 };
 
+RingMorph.prototype.isEmptySlot = function () {
+    return !this.contents();
+};
+
 // RingMorph zebra coloring
 
 RingMorph.prototype.fixBlockColor = function (nearest, isForced) {


### PR DESCRIPTION
This is the fix I alluded to in https://github.com/jmoenig/Snap/issues/2836. If empty rings are not considered empty slots by design, then this can be rejected, of course :) I was going to wait to open the PR but thought it might actually help to explain my thinking in the comments in the issue!