### PR TITLE
Hide all primitives works in Single Palette mode.

### DIFF
--- a/src/gui.js
+++ b/src/gui.js
@@ -5797,7 +5797,7 @@ IDE_Morph.prototype.switchToDevMode = function () {
 
 IDE_Morph.prototype.flushBlocksCache = function (category) {
     // if no category is specified, the whole cache gets flushed
-    if (category) {
+    if (category && category !== 'unified') {
         this.stage.primitivesCache[category] = null;
         this.stage.children.forEach(m => {
             if (m instanceof SpriteMorph) {

--- a/src/objects.js
+++ b/src/objects.js
@@ -3064,13 +3064,16 @@ SpriteMorph.prototype.freshPalette = function (category) {
                 function () {
                     var defs = SpriteMorph.prototype.blocks;
                     Object.keys(defs).forEach(sel => {
-                        if (defs[sel].category === category) {
+                        if (defs[sel].category === category || category === 'unified') {
                             StageMorph.prototype.hiddenPrimitives[sel] = true;
                         }
                     });
-                    (more[category] || []).forEach(sel =>
+                    if (category === 'unified') {
+                        more.unified = Object.values(more).reduce((x, y) => x.concat(y));
+                    }
+                    (more[category] || []).forEach(sel => {
                         StageMorph.prototype.hiddenPrimitives[sel] = true
-                    );
+                    });
                     ide.flushBlocksCache(category);
                     ide.refreshPalette();
                 }

--- a/src/objects.js
+++ b/src/objects.js
@@ -3071,9 +3071,9 @@ SpriteMorph.prototype.freshPalette = function (category) {
                     if (category === 'unified') {
                         more.unified = Object.values(more).reduce((x, y) => x.concat(y));
                     }
-                    (more[category] || []).forEach(sel => {
+                    (more[category] || []).forEach(sel =>
                         StageMorph.prototype.hiddenPrimitives[sel] = true
-                    });
+                    );
                     ide.flushBlocksCache(category);
                     ide.refreshPalette();
                 }


### PR DESCRIPTION
This is a small fix to make the 'hide primitives' function work as before.

* also, calling "flushBlocksCache" in unified/single mode clears the whole cache