### PR TITLE
Display block with error

### DIFF
--- a/src/blocks.js
+++ b/src/blocks.js
@@ -4192,24 +4192,6 @@ BlockMorph.prototype.scriptPic = function () {
     return pic;
 };
 
-BlockMorph.prototype.errorPic = function () {
-    // return a picture of myself, that approximately fits in "one line"
-    // filter any blocks beneath me, so that users only see the first
-    // block that caused an error.
-    var block = this;
-    if (block.selector === 'reportGetVar') {
-        // if I am a single variable, show my caller in the output.
-        block = block.parent;
-    }
-    if (block.nextBlock) {
-        var copy = block.fullCopy();
-        copy.removeChild(copy.nextBlock());
-        return copy.fullImage();
-    }
-
-    return block.fullImage();
-}
-
 BlockMorph.prototype.fullImage = function () {
     // answer a canvas image meant for (semi-) transparent blocks
     // that lets the background shine through

--- a/src/blocks.js
+++ b/src/blocks.js
@@ -4196,13 +4196,18 @@ BlockMorph.prototype.errorPic = function () {
     // return a picture of myself, that approximately fits in "one line"
     // filter any blocks beneath me, so that users only see the first
     // block that caused an error.
-    if (this.nextBlock) {
-        var copy = this.fullCopy();
+    var block = this;
+    if (block.selector === 'reportGetVar') {
+        // if I am a single variable, show my caller in the output.
+        block = block.parent;
+    }
+    if (block.nextBlock) {
+        var copy = block.fullCopy();
         copy.removeChild(copy.nextBlock());
         return copy.fullImage();
     }
 
-    return this.fullImage();
+    return block.fullImage();
 }
 
 BlockMorph.prototype.fullImage = function () {

--- a/src/blocks.js
+++ b/src/blocks.js
@@ -4192,6 +4192,19 @@ BlockMorph.prototype.scriptPic = function () {
     return pic;
 };
 
+BlockMorph.prototype.errorPic = function () {
+    // return a picture of myself, that approximately fits in "one line"
+    // filter any blocks beneath me, so that users only see the first
+    // block that caused an error.
+    if (this.nextBlock) {
+        var copy = this.fullCopy();
+        copy.removeChild(copy.nextBlock());
+        return copy.fullImage();
+    }
+
+    return this.fullImage();
+}
+
 BlockMorph.prototype.fullImage = function () {
     // answer a canvas image meant for (semi-) transparent blocks
     // that lets the background shine through

--- a/src/threads.js
+++ b/src/threads.js
@@ -1176,9 +1176,9 @@ Process.prototype.errorBubble = function (error, element) {
     // above the text of error.
     var errorMorph = new AlignmentMorph('column', 5),
         errorIsNested = isNil(element.world()),
-        errorPrefix = errorIsNested ? localize('Inside a custom block') + ':\n' : '',
+        errorPrefix = errorIsNested ? `${localize('Inside a custom block')}:\n`: '',
         errorMessage = new TextMorph(
-            errorPrefix + localize(error.name) + ':\n' + error.message,
+            `${errorPrefix}${localize(error.name)}:\n${localize(error.message)}`,
             SyntaxElementMorph.prototype.fontSize
         ),
         img, blockImage;
@@ -1186,22 +1186,13 @@ Process.prototype.errorBubble = function (error, element) {
     errorMorph.add(errorMessage);
     errorMorph.alpha = 0;
     if (errorIsNested) {
-        window.element = element;
+        errorMorph.text += `\n${localize('The error occured at:')}\n`;
         img = element.errorPic();
         blockImage = new Morph();
         blockImage.isCachingImage = true;
-        blockImage.bounds.setWidth(img.width);
-        blockImage.bounds.setHeight(img.height);
-
-        // blockImage.setExtent(new Point(img.width, img.height));
+        blockImage.setExtent(new Point(img.width, img.height));
         blockImage.cachedImage = img;
-        // blockImage.image = img;
-        // errorMessage.setTop(blockImage.height() + 2);
         errorMorph.add(blockImage);
-        // errorMorph.setExtent(new Point(
-        //     Math.max(blockImage.width(), errorMessage.width()),
-        //     blockImage.height() + errorMessage.height()
-        // ));
         errorMorph.fixLayout();
     }
 

--- a/src/threads.js
+++ b/src/threads.js
@@ -1181,18 +1181,16 @@ Process.prototype.errorBubble = function (error, element) {
             `${errorPrefix}${localize(error.name)}:\n${localize(error.message)}`,
             SyntaxElementMorph.prototype.fontSize
         ),
-        img, blockImage;
+        blockToShow = element;
 
     errorMorph.add(errorMessage);
-    errorMorph.alpha = 0;
     if (errorIsNested) {
+        if (blockToShow.selector === 'reportGetVar') {
+            // if I am a single variable, show my caller in the output.
+            blockToShow = blockToShow.parent;
+        }
         errorMorph.text += `\n${localize('The error occured at:')}\n`;
-        img = element.errorPic();
-        blockImage = new Morph();
-        blockImage.isCachingImage = true;
-        blockImage.setExtent(new Point(img.width, img.height));
-        blockImage.cachedImage = img;
-        errorMorph.add(blockImage);
+        errorMorph.add(blockToShow);
         errorMorph.fixLayout();
     }
 


### PR DESCRIPTION
This replaces #1781 -- I've remade the commits since the history was kind of a mess and the original commit in that PR was quite old. I think this is a nicer implementation anyway. :) 

This doesn't do much to always try to find the best thing to show, but it does include a case for when a single variable errors, it shows the caller. Presumably there's other cases where we could find improvements....

<img width="474" alt="Screen Shot 2021-07-06 at 7 03 24 PM" src="https://user-images.githubusercontent.com/1505907/124689371-412aa180-de8d-11eb-8016-e2333bb07587.png">
