### PR TITLE
follow up fixes for single palette

### DIFF
--- a/src/objects.js
+++ b/src/objects.js
@@ -3118,7 +3118,7 @@ SpriteMorph.prototype.freshPalette = function (category) {
     if (category === 'unified') {
         // In a Unified Palette custom blocks appear following each category,
         // but there is only 1 make a block button (at the end).
-        // arrange the blocks in the unified palette column-wise:er
+        // arrange the blocks in the unified palette column-wise:
         let cat1 = this.categories.slice(0, 8),
             cat2 = this.categories.slice(8);
 

--- a/src/objects.js
+++ b/src/objects.js
@@ -2847,10 +2847,7 @@ SpriteMorph.prototype.customBlockTemplatesForCategory = function (category) {
         isInherited = false, block, inheritedBlocks;
 
     function addCustomBlock(definition) {
-        if (!definition.isHelper &&
-            (definition.category === category ||
-            (Array.isArray(category) && category.includes(definition.category)))
-        ) {
+        if (!definition.isHelper && definition.category === category) {
             block = definition.templateInstance();
             if (isInherited) {block.ghost(); }
             blocks.push(block);
@@ -3047,15 +3044,9 @@ SpriteMorph.prototype.freshPalette = function (category) {
         }
 
         function hasHiddenPrimitives() {
-            console.log('HAS HIDDEN PRIMITIVES CALLED');
             var defs = SpriteMorph.prototype.blocks,
                 hiddens = StageMorph.prototype.hiddenPrimitives;
-                console.log(Object.keys(hiddens).some(any =>
-                    !isNil(defs[any]) && (category === 'unified' ||
-                        (defs[any].category === category ||
-                            contains((more[category] || []), any)))
-                ))
-                return Object.keys(hiddens).some(any =>
+            return Object.keys(hiddens).some(any =>
                 !isNil(defs[any]) && (category === 'unified' ||
                     (defs[any].category === category ||
                         contains((more[category] || []), any)))
@@ -3143,14 +3134,10 @@ SpriteMorph.prototype.freshPalette = function (category) {
                 showHeader = !['lists', 'other'].includes(category) &&
                     (primitives.some(item => item instanceof BlockMorph) || customs.length);
 
-            console.log('SHow header?', showHeader, category)
-            console.log(primitives.some(item => item instanceof BlockMorph))
             return blocks.concat(
                 showHeader ? header : [],
-                primitives,
-                '=',
-                customs,
-                '='
+                primitives, '=',
+                customs, '='
             );
         }, []);
     } else {
@@ -3160,14 +3147,14 @@ SpriteMorph.prototype.freshPalette = function (category) {
     blocks.push('=');
     blocks.push(this.makeBlockButton(category));
 
-    if (category === 'variables') {
-        category = ['variables', 'lists', 'other'];
-    }
-
     if (category !== 'unified') {
         blocks.push('=');
         blocks.push(...this.customBlockTemplatesForCategory(category));
+    } else if (category === 'variables') {
+        blocks.push(...this.customBlockTemplatesForCategory('lists'));
+        blocks.push(...this.customBlockTemplatesForCategory('other'));
     }
+
 
     blocks.forEach(block => {
         if (block === null) {

--- a/src/objects.js
+++ b/src/objects.js
@@ -3048,14 +3048,14 @@ SpriteMorph.prototype.freshPalette = function (category) {
 
         function hasHiddenPrimitives() {
             console.log('HAS HIDDEN PRIMITIVES CALLED');
-            console.log(Object.keys(hiddens).some(any =>
-                !isNil(defs[any]) && (category === 'unified' ||
-                    (defs[any].category === category ||
-                        contains((more[category] || []), any)))
-            ))
             var defs = SpriteMorph.prototype.blocks,
                 hiddens = StageMorph.prototype.hiddenPrimitives;
-            return Object.keys(hiddens).some(any =>
+                console.log(Object.keys(hiddens).some(any =>
+                    !isNil(defs[any]) && (category === 'unified' ||
+                        (defs[any].category === category ||
+                            contains((more[category] || []), any)))
+                ))
+                return Object.keys(hiddens).some(any =>
                 !isNil(defs[any]) && (category === 'unified' ||
                     (defs[any].category === category ||
                         contains((more[category] || []), any)))
@@ -3127,7 +3127,7 @@ SpriteMorph.prototype.freshPalette = function (category) {
     if (category === 'unified') {
         // In a Unified Palette custom blocks appear following each category,
         // but there is only 1 make a block button (at the end).
-        // arrange the blocks in the unified palette column-wise:
+        // arrange the blocks in the unified palette column-wise:er
         let cat1 = this.categories.slice(0, 8),
             cat2 = this.categories.slice(8);
 
@@ -3136,20 +3136,23 @@ SpriteMorph.prototype.freshPalette = function (category) {
         ).concat(cat1.filter(
             (elem, idx) => idx % 2 === 1)
         ).concat(cat2);
-        blocks = unifiedCategories.reduce((blocks, category) =>
-            blocks.concat(
-                category === 'lists' ?
-                    [] :
-                    [
-                        this.categoryText(category),
-                        '-'
-                    ],
-                this.getPrimitiveTemplates(category),
+        blocks = unifiedCategories.reduce((blocks, category) => {
+            let header = [ this.categoryText(category), '-' ],
+                primitives = this.getPrimitiveTemplates(category),
+                customs = this.customBlockTemplatesForCategory(category),
+                showHeader = !['lists', 'other'].includes(category) &&
+                    (primitives.some(item => item instanceof BlockMorph) || customs.length);
+
+            console.log('SHow header?', showHeader, category)
+            console.log(primitives.some(item => item instanceof BlockMorph))
+            return blocks.concat(
+                showHeader ? header : [],
+                primitives,
                 '=',
-                this.customBlockTemplatesForCategory(category),
+                customs,
                 '='
-            ),
-            []);
+            );
+        }, []);
     } else {
         // ensure we do not modify the cached array
         blocks = this.getPrimitiveTemplates(category).slice();

--- a/src/objects.js
+++ b/src/objects.js
@@ -3041,7 +3041,18 @@ SpriteMorph.prototype.freshPalette = function (category) {
                     ]
             };
 
+        if (category === 'unified') {
+            more.unified = Object.values(more).reduce((x, y) =>
+                x.concat(y));
+        }
+
         function hasHiddenPrimitives() {
+            console.log('HAS HIDDEN PRIMITIVES CALLED');
+            console.log(Object.keys(hiddens).some(any =>
+                !isNil(defs[any]) && (category === 'unified' ||
+                    (defs[any].category === category ||
+                        contains((more[category] || []), any)))
+            ))
             var defs = SpriteMorph.prototype.blocks,
                 hiddens = StageMorph.prototype.hiddenPrimitives;
             return Object.keys(hiddens).some(any =>
@@ -3082,10 +3093,6 @@ SpriteMorph.prototype.freshPalette = function (category) {
                             StageMorph.prototype.hiddenPrimitives[sel] = true;
                         }
                     });
-                    if (category === 'unified') {
-                        more.unified = Object.values(more).reduce((x, y) =>
-                            x.concat(y));
-                    }
                     (more[category] || []).forEach(sel =>
                         StageMorph.prototype.hiddenPrimitives[sel] = true
                     );


### PR DESCRIPTION
* fix hiding/showing primitives when using the variables palette (in not single palette mode)
* in single palette mode, do _not_ show labels if there are no blocks beneath the label.

The second fix is useful because in current master, you get overlapping labels when hiding all blocks. But also for some of the microworld-y things, we don't want to call extra attention to the fact that there could be some other block.