### PR TITLE
Better handling of blocked cloud URLs

### DIFF
--- a/src/threads.js
+++ b/src/threads.js
@@ -3666,8 +3666,18 @@ Process.prototype.reportURL = function (url) {
 
 Process.prototype.checkURLAllowed = function (url) {
     if ([ 'users', 'logout', 'projects', 'collections' ].some(
-        which => url.match(`snap\.berkeley\.edu.*${which}`))
-    ) {
+        pathPart => {
+            // Check out whether we're targeting one of the remote domains
+            return Object.values(Cloud.prototype.knownDomains).filter(
+                each => each.includes('snap')
+            ).some(
+                domain => url.match(
+                    // Check only against the host -not the protocol, path or
+                    // port- of the domain
+                    new RegExp(`${(new URL(domain)).host}.*${pathPart}`, 'i'))
+            )
+        }
+    )) {
         throw new Error('Request blocked');
     }
 };


### PR DESCRIPTION
Check URL against all known cloud domains, and make the regex case insensitive.