### PR TITLE
Default to making speech bubbles persisnt until clicked

### DIFF
--- a/src/blocks.js
+++ b/src/blocks.js
@@ -2158,7 +2158,7 @@ SyntaxElementMorph.prototype.showBubble = function (value, exportPic, target) {
         txt,
         img,
         morphToShow,
-        isClickable = false,
+        isClickable = true,
         ide = this.parentThatIsA(IDE_Morph) || target.parentThatIsA(IDE_Morph),
         anchor = this,
         pos = this.rightCenter().add(new Point(2, 0)),


### PR DESCRIPTION
This changes the default of all speech bubbles to be presistent.

There are a few reasons why I think this is a good change:
* 'Mouse over to dismiss' is kind of a confusing design. With longer output,
it prevents you from using the cursor to track words your reading. It's a particular challenge
for error messages.
* Scratch 3 (not sure about 2) does this as well.
* In the future I think it makes sense to expand the options you can do with all
speech bubbles. It would be great to be able to add right click functionality or copy to clipboard tools. Right now list outputs are interactive, but I think it would be awesome if all outputs could be. (These features can be added over time, but a major version seems like a great time to make this change.)