### PR TITLE
Fixing translation issue of library names

### DIFF
--- a/src/gui.js
+++ b/src/gui.js
@@ -8970,7 +8970,8 @@ LibraryImportDialogMorph.prototype.installLibrariesList = function () {
         element => element.name,
         null,
         () => this.importLibrary(),
-        '~' // separator
+        '~', // separator
+        false // verbatim
     );
 
     this.fixListFieldItemColors();

--- a/src/morphic.js
+++ b/src/morphic.js
@@ -10764,7 +10764,7 @@ ListMorph.prototype = new ScrollFrameMorph();
 ListMorph.prototype.constructor = ListMorph;
 ListMorph.uber = ScrollFrameMorph.prototype;
 
-function ListMorph(elements, labelGetter, format, onDoubleClick, separator) {
+function ListMorph(elements, labelGetter, format, onDoubleClick, separator, verbatim) {
 /*
     passing a format is optional. If the format parameter is specified
     it has to be of the following pattern:
@@ -10798,7 +10798,8 @@ function ListMorph(elements, labelGetter, format, onDoubleClick, separator) {
         },
         format || [],
         onDoubleClick, // optional callback
-        separator // string indicating a horizontal line between items
+        separator, // string indicating a horizontal line between items
+        verbatim
     );
 }
 
@@ -10807,7 +10808,8 @@ ListMorph.prototype.init = function (
     labelGetter,
     format,
     onDoubleClick,
-    separator
+    separator,
+    verbatim
 ) {
     ListMorph.uber.init.call(this);
 
@@ -10824,6 +10826,7 @@ ListMorph.prototype.init = function (
     this.action = null;
     this.doubleClickAction = onDoubleClick || null;
     this.separator = separator || '';
+    this.verbatim = typeof verbatim === 'undefined' ? true : verbatim;
     this.acceptsDrops = false;
     this.buildListContents();
 };
@@ -10871,7 +10874,7 @@ ListMorph.prototype.buildListContents = function () {
                 italic,
                 this.doubleClickAction,
                 null, // shortcut
-                true // verbatim - don't translate
+                this.verbatim // don't translate
             );
         }
     });


### PR DESCRIPTION
Fixing #2928
-  Adding *verbatim* param to ListMorph (default *true*)
- *ListMorph.buildListContents* function use now this *verbatim* param to create the list (in *listContents.addItem* action)
- And then, *installLibrariesList* use it with *verbatim = false" to allow translations
