### PR TITLE
Better Support Multi-Byte Emoji with `split` and `unicode`

### DIFF
--- a/src/lists.js
+++ b/src/lists.js
@@ -922,7 +922,7 @@ List.prototype.asCSV = function () {
 
     var items = this.itemsArray(),
         rows = [];
-    
+
     function encodeCell(atomicValue) {
         var string = isNil(atomicValue) ? '' : atomicValue.toString(),
             cell;
@@ -932,7 +932,7 @@ List.prototype.asCSV = function () {
             return string;
         }
         cell = ['\"'];
-        string.split('').forEach(letter => {
+        Array.from(string).forEach(letter => {
             cell.push(letter);
             if (letter === '\"') {
                 cell.push(letter);
@@ -1094,7 +1094,7 @@ List.prototype.blockify = function (limit = 500, count = [0]) {
 
     block.isDraggable = true;
     slots.removeInput();
-    
+
     // fill the slots with the data
     for (i = 0; i < len && count[0] < limit; i += 1) {
         value = this.at(i + 1);

--- a/src/threads.js
+++ b/src/threads.js
@@ -4420,6 +4420,8 @@ Process.prototype.reportBasicTextSplit = function (string, delimiter) {
         str = str.trim();
         del = /\s+/;
         break;
+    case isNil(delimiter):
+    case '':
     case 'letter':
         return new List(Array.from(str));
     case 'csv':
@@ -4433,7 +4435,7 @@ Process.prototype.reportBasicTextSplit = function (string, delimiter) {
         return this.parseCSVfields(string);
     */
     default:
-        del = isNil(delimiter) ? '' : delimiter.toString();
+        del = delimiter.toString();
     }
     return new List(str.split(del));
 };

--- a/src/threads.js
+++ b/src/threads.js
@@ -4421,7 +4421,7 @@ Process.prototype.reportBasicTextSplit = function (string, delimiter) {
         del = /\s+/;
         break;
     case 'letter':
-        return Array.from(str);
+        return new List(Array.from(str));
     case 'csv':
         return this.parseCSV(string);
     case 'json':

--- a/src/threads.js
+++ b/src/threads.js
@@ -4344,15 +4344,16 @@ Process.prototype.reportStringSize = function (data) {
 };
 
 Process.prototype.reportUnicode = function (string) {
-    var str;
+    var str, unicodeList;
 
     if (this.enableHyperOps) {
         if (string instanceof List) {
             return string.map(each => this.reportUnicode(each));
         }
         str = isNil(string) ? '\u0000' : string.toString();
-        if (str.length > 1) {
-            return this.reportUnicode(new List(Array.from(str)));
+        unicodeList = Array.from(str);
+        if (unicodeList.length > 1) {
+            return this.reportUnicode(new List(unicodeList));
         }
     } else {
         str = isNil(string) ? '\u0000' : string.toString();

--- a/src/threads.js
+++ b/src/threads.js
@@ -4352,7 +4352,7 @@ Process.prototype.reportUnicode = function (string) {
         }
         str = isNil(string) ? '\u0000' : string.toString();
         if (str.length > 1) {
-            return this.reportUnicode(new List(str.split('')));
+            return this.reportUnicode(new List(Array.from(str)));
         }
     } else {
         str = isNil(string) ? '\u0000' : string.toString();
@@ -4421,8 +4421,7 @@ Process.prototype.reportBasicTextSplit = function (string, delimiter) {
         del = /\s+/;
         break;
     case 'letter':
-        del = '';
-        break;
+        return Array.from(str);
     case 'csv':
         return this.parseCSV(string);
     case 'json':


### PR DESCRIPTION
The gist is that `Array.from(str)` is much much more aware of emoji than
`str.split('')` which does a naïve one-byte split.

Consider some of these examples:
'🥰' -- a two byte emoji
'🧙🏻‍♂️' -- a modern 7 byte emoji!
This is a male wizard with a skin tone.

The later case still gets split into a list of 5 parts, but each of those 5 items is technically a valid character on its own.

Project: https://snap.berkeley.edu/versions/dev/snap.html#present:Username=cycomachead&ProjectName=Emoji%20tests

## Before Pics
![untitled script pic-2](https://user-images.githubusercontent.com/1505907/145693893-1d730233-61f4-479c-af98-a7edd1ae4ba3.png)
![untitled script pic](https://user-images.githubusercontent.com/1505907/145693896-4a05955f-d1c4-410e-9ae4-1165f0b2afac.png)

## After Pics
![untitled script pic-4](https://user-images.githubusercontent.com/1505907/145693900-f2425a5d-ae66-4f57-83c2-d3dcc798235a.png)
![untitled script pic-3](https://user-images.githubusercontent.com/1505907/145693901-fb93eaef-65fc-4a65-8052-2064020d5eb3.png)


