### PR TITLE
use `Array.from` to report string length.

### DIFF
--- a/src/threads.js
+++ b/src/threads.js
@@ -4344,7 +4344,7 @@ Process.prototype.reportStringSize = function (data) {
     if (data instanceof List) { // catch a common user error
         return data.length();
     }
-    return isNil(data) ? 0 : data.toString().length;
+    return isNil(data) ? 0 : Array.from(data.toString()).length;
 };
 
 Process.prototype.reportUnicode = function (string) {


### PR DESCRIPTION
This is another fix to better support multi-byte emoji

Test project: http://localhost:8000/snap/snap.html#present:Username=cycomachead&ProjectName=Emoji%20tests
![untitled script pic-2](https://user-images.githubusercontent.com/1505907/149218532-e29acbd5-817e-4ef9-919d-a01d0dd3f4c2.png)

Prior to this, the above was false, because `length of 👨‍👩‍👦‍👦` returned 11. Now they each return 7, which is slightly confusing, but expected. :) 
