### PR TITLE
JSCompiler stuff

### DIFF
--- a/src/threads.js
+++ b/src/threads.js
@@ -7728,7 +7728,7 @@ JSCompiler.prototype.escape = function(string) {
     while (len > i) {
         char = string.charAt(i++);
         if (" abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$%&'()*+,-./:;<=>?@[]^_`{|}~".indexOf(char) === -1) {
-            escaped += "\\u" + (char.charCodeAt(0) | 0x10000).toString(16).substring(1);
+            escaped += '\\u' + (char.charCodeAt(0) | 0x10000).toString(16).substring(1);
         } else {
             escaped += char;
         }

--- a/src/threads.js
+++ b/src/threads.js
@@ -7657,7 +7657,7 @@ JSCompiler.prototype.compileInputs = function (array) {
 };
 
 JSCompiler.prototype.compileInput = function (inp) {
-     var value, type;
+    var value, type;
 
     if (inp.isEmptySlot && inp.isEmptySlot()) {
         // implicit formal parameter

--- a/src/threads.js
+++ b/src/threads.js
@@ -7724,11 +7724,14 @@ JSCompiler.prototype.compileInput = function (inp) {
 JSCompiler.prototype.escape = function(string) {
     // make sure string is a string
     string += '';
-    var len = string.length, i = 0, char, escaped = '';
+    var len = string.length, i = 0, char, escaped = '', safe_chars = 
+        ' abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$' +
+        "%&'()*+,-./:;<=>?@[]^_`{|}~";
     while (len > i) {
         char = string.charAt(i++);
-        if (" abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$%&'()*+,-./:;<=>?@[]^_`{|}~".indexOf(char) === -1) {
-            escaped += '\\u' + (char.charCodeAt(0) | 0x10000).toString(16).substring(1);
+        if (safe_chars.indexOf(char) === -1) {
+            escaped += '\\u' + (char.charCodeAt(0) | 0x10000)
+                .toString(16).substring(1);
         } else {
             escaped += char;
         }


### PR DESCRIPTION
1. use `new Map()` instead of `{}` for gensyms 
2. use `arguments[arguments.length - 1].selector(arg0, arg1, arg2)` instead of `arguments[arguments.length - 1].selector.apply(arguments[arguments.length - 1], [arg0, arg1, arg2])` (that was compiled example, not actual code)
3. escape in `value instanceof Array`
4. `// fix for blocks like (x position)`
5. new `escape` function that makes sure `string` is a string and escapes weird unicode chars but doesn't escape `'` because compiler always puts escaped string in double quotes (`"`)

Also, how do you get `Array` object in `Snap!`?

Tell me what I did wrong if I did something wrong.