### PR TITLE
Change browser tab title when project title changes.

### DIFF
--- a/src/gui.js
+++ b/src/gui.js
@@ -1258,6 +1258,9 @@ IDE_Morph.prototype.createControlBar = function () {
         scene = myself.scenes.at(1) !== myself.scene ?
                 ' (' + myself.scene.name + ')' : '';
         name = (myself.getProjectName() || localize('untitled'));
+        if (name !== null && name !== 'untitled') {
+            document.title = "Snap! " + name;
+        }
         txt = new StringMorph(
             prefix + name +  scene + suffix,
             14,


### PR DESCRIPTION
(I looked at the contributing guidelines and saw the thing about changesets but also looked at the recent pull requests against your repo and it looks like at least some of them are normal PRs that make small changes to existing files. Happy to try to do this some other way if you want me to but this seems simplest to me.)

Anyway, I got tired of not being able to find the right Snap tab in my browser because they're all titled the same thing, so I cooked up this change to set the `document.title` when the project changes (i.e. on saves and opens).

I've tested this in local development but I assume I can't save to the cloud safely so I didn't test that. But if I've found the right code path to do this in it should change whenever the title in the UI changes.

Hoping you'll find this useful as it will make my Snap! programming that much more pleasant.