### PR TITLE
Remove mentions of changesets from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,26 +1,16 @@
 # How to contribute
 
-Attached is the current development code base for BYOB4 a.k.a. Snap. It consists of
-several JavaScript, HTML and text files, and while some of it may be functional
-most parts will be in flux and subject to frequent, even fundamental modifications.
-This document lays out a few simple guidelines ensuring that collaborative code
-contribution works out.
+Attached is the current development code base for Snap! (formerly known as BYOB4).
+It consists of several JavaScript, HTML and text files, and while some of it may
+be functional most parts will be in flux and subject to frequent, even fundamental
+modifications. This document lays out a few simple guidelines ensuring that
+collaborative code contribution works out.
 
 
 ## Coding
 
-
-### Working with changesets
-
-You'll often want to change or add code in existing JS files. Please don't. Instead
-use a changeset. The way I always do it myself is to copy the empty `changeset.js`
-file and rename it to something like `JensChangesToMorphic.js`.
-
-Into this file I write all the functions I want to add to Morphic. If I want to
-change a function in Morphic.js I copy it to the changeset and edit it there. Then
-I always validate the changeset with JSLint.com.
-
-Please check your code frequently with JSLint!
+Please check your code frequently with JSLint, either at JSlint.com or
+via a locally installed jslint.
 
 For our Snap code set JSLint's settings to:
 
@@ -91,37 +81,11 @@ code chunks, therefore:
 (don't worry, I'm not talking about formal UnitTest Suites or other BDSM software
 fetishes, just about playing with what you're creating while you're doing it)
 
-To test your changesets just add another line in the html stub file with your
-changeset. Make sure to put your changeset **after** Morphic.js and Blocks.js and
-whichever libraries are already included, so it'll actually get used.
-
-In your changeset override the world's `customMorphs` function so it returns a
-list of instances of your Morphs. For `Blocks.js` that code is:
-
-```javascript
-var BlockMorph;
-var ScriptsMorph;
-
-WorldMorph.prototype.customMorphs = function () {
-	var sm = new ScriptsMorph();
-	sm.setExtent(new Point(800, 600));
-	return [
-		new BlockMorph(),
-		sm
-	];
-};
-```
-
-Just modify this code so it returns your list of sample Morphs instead of
-`BlockMorph` and `ScriptsMorph` instances.
-
-Once you've added this code to your changeset you can open your sample html file
-in your browser, and you'll find your sample Morphs in the World's DEMO menu.
-
+To test your changes locally, just open `index.html` in your browser.
 
 ### Inspectors
 
-To actually test play with your Morphs you can right-click on them and open an
+To actually play with your Morphs you can right-click on them and open an
 inspector on them. You can open more than one inspector on each object. The
 inspector pretty much works the same as in Smalltalk. It even has an evaluation
 pane at the bottom, in which you can type in any JS code, mark it with your mouse
@@ -134,11 +98,10 @@ object.
 
 ### Source Code Mgmt
 
-The good thing about changesets is that you can continue working on them regardless
-of new dev releases that happen in the meantime. When you feel you've got something
-that's finished just send me your changeset, and I'll work all the changesets into
-the Snap codebase and release another dev version. That way there will always (and
-frequently) be a harmonized common code base.
+Snap! is hosted on Github at https://github.com/jmoenig/Snap. You can make a fork
+via the Github "Fork" button and then create a PR by pushing a branch to your fork
+and then creating a PR against the master brancd of `jmoenig/Snap`. You can see
+current PRs here: https://github.com/jmoenig/Snap/pulls
 
 ---
 


### PR DESCRIPTION
I wasn't sure if your reply the other day meant that you don't use change sets at all any more. If they are completely a relic of the past, here are some edits to `CONTRIBUTING.md` that take out mentions of them. If I misunderstood and this isn't useful, feel free to toss it out.