### PR TITLE
Add an ide_all_blocks reporter to extensions

### DIFF
--- a/src/extensions.js
+++ b/src/extensions.js
@@ -55,13 +55,13 @@ var SnapExtensions = {
     used as extension primitives for blocks or dynamic dropdown menus. Block
     extensions are stored in the "primitives" dictionary of SnapExtensions,
     dynamic dropdown menus in the "menus" section.
-    
+
     You can also extend Snap! with your own externally hosted JavaScript file(s)
     and have them add your own extension primitives and menus to the global
     SnapExtensions dictionaries. This lets you provide libraries to support
     special APIs and custom hardware.
 
-    
+
     1. Primitives (additional blocks)
     =================================
     The names under which primitives are stored will apear in the dropdown
@@ -131,9 +131,9 @@ var SnapExtensions = {
     You can provide extensions for your custom hardware or for arbitrary APIs
     or extend Snap! with JavaScript libraries from other parties. You can
     load additional JavaScript files using the
-    
+
         src_load(url)
-    
+
     extension primitive inside Snap, which you can find using Snap's search bar
     in the IDE. The loading primitive will wait until the source file has fully
     loaded and its defined functions are ready to be called.
@@ -142,7 +142,7 @@ var SnapExtensions = {
     This lets you lazily initialize your extension by simply adding a
     "src_load(url)" command for your external JS file before calling any of its
     added functions.
-    
+
 
     4. Miscellaneous
     ================
@@ -837,6 +837,38 @@ SnapExtensions.primitives.set(
 
 // IDE (ide_):
 
+// Returns all blocks in the editor, regardlss of visibility
+SnapExtensions.primitives.set(
+    'ide_all_blocks()',
+    function () {
+        let stage = this.parentThatIsA(StageMorph),
+            allSprites = stage.children.filter(morph => morph instanceof SpriteMorph);
+        return new List(
+            stage.globalBlocks.concat(
+                allSprites.map(sprite => sprite.allBlocks(true)).flat()
+            ).map(
+                def => def.blockInstance().reify()
+            ).concat(
+                SpriteMorph.prototype.categories.reduce(
+                    (blocks, category) => blocks.concat(
+                        this.getPrimitiveTemplates(
+                            category
+                        ).filter(
+                            each => each instanceof BlockMorph
+                        ).map(block => {
+                            console.log(block)
+                            let instance = block.fullCopy();
+                            instance.isTemplate = false;
+                            return instance.reify();
+                        })
+                    ),
+                    []
+                )
+            )
+        );
+    }
+);
+
 SnapExtensions.primitives.set(
     'ide_hide(block)',
     function (context, proc) {
@@ -1112,14 +1144,14 @@ SnapExtensions.primitives.set(
             }
             if (reader) {await reader.releaseLock(); }
         }) (port);
-     
+
         if (acc.result !== false) {
             if (acc.result instanceof  Error) {
                 throw acc.result;
             }
             return acc.result;
         }
-     
+
         return (port._bklog?.length > 0) ?
             new List( Array.from( port._bklog.splice(0)))
             : true;

--- a/src/extensions.js
+++ b/src/extensions.js
@@ -856,7 +856,6 @@ SnapExtensions.primitives.set(
                         ).filter(
                             each => each instanceof BlockMorph
                         ).map(block => {
-                            console.log(block)
                             let instance = block.fullCopy();
                             instance.isTemplate = false;
                             return instance.reify();


### PR DESCRIPTION
This **does not** filter hidden blocks, nor hat blocks.
This makes it much easier than `my(blocks)` to build extensions that 
interactively change the palette.