### PR TITLE
fix dev mode right click `pic...` not working

### DIFF
--- a/src/morphic.js
+++ b/src/morphic.js
@@ -4510,7 +4510,27 @@ Morph.prototype.developersMenu = function () {
     );
     menu.addItem(
         "pic...",
-        () => window.open(this.fullImage().toDataURL()),
+        () => {
+            var imgURL = this.fullImage().toDataURL(), doc, body, tag;
+            try {
+                doc = window.open('', '_blank', 'popup').document;
+                body = doc.getElementsByTagName('body')[0];
+                str = '' + this;
+                doc.title = str;
+                tag = doc.createElement('h1');
+                tag.textContent = str;
+                body.appendChild(tag);
+                tag = doc.createElement('img');
+                tag.alt = str;
+                tag.src = imgURL;
+                body.appendChild(tag);
+            } catch (error) {
+                console.warn(
+                    'failed to popup pic, morph:%O, error:%O, image URL:%O',
+                    this, error, [imgURL]
+                );
+            }
+        },
         'open a new window\nwith a picture of this morph'
     );
     menu.addLine();


### PR DESCRIPTION
`window.open` with `data:` URIs doesn't work in modern browsers: https://www.bleepingcomputer.com/news/security/firefox-will-block-navigational-data-uris-as-part-of-an-anti-phishing-feature/

made `pic...` popup look like this:
<img src=https://user-images.githubusercontent.com/91378413/183448801-afd5a829-840d-432f-89aa-5f09fdde06d3.png>