### PR TITLE
Fixing issue changing color dimensions

### DIFF
--- a/src/objects.js
+++ b/src/objects.js
@@ -4675,7 +4675,7 @@ SpriteMorph.prototype.setColorDimension = function (idx, num) {
     if (!this.costume) {
         this.rerender();
     }
-    this.gotoXY(x, y);
+    this.silentGotoXY(x, y);
 };
 
 SpriteMorph.prototype.getColorDimension = function (idx) {


### PR DESCRIPTION
Hi Jens,

Yesterday I saw an issue from a student question.

- Example of the problem: (https://snap.berkeley.edu/snap/snap.html#present:Username=jguille2&ProjectName=issueChangingColorDim)
- If you don't get those "annoying dots", test changing the visual stage dimensions.
- Why? You know. Again JS floating point number precision.
  - Our function `setColorDimension` has a `gotoXY`
  - And then, the problem is with the precision of the position. The sprite has not to move anywhere... but the position calculation and the `gotoXY`action makes a little movement.
  - And so, if pen is down, a dot is drawn.

Solution. We can think about this `gotoXY` requirement... and also we can think about roundings and the general JS numbers precision.
But in this case, we have the `silentGotoXY` function and I think this is the best solution here. The movement is still there... but no dots are  drawn.

Joan