### PR TITLE
check whether context has scale method before calling it in retina support patch

### DIFF
--- a/src/morphic.js
+++ b/src/morphic.js
@@ -1802,7 +1802,7 @@ function enableRetinaSupport() {
                 context.restore();
                 context.save();
                 */
-                context.scale(pixelRatio, pixelRatio);
+                if (context.scale) { context.scale(pixelRatio, pixelRatio); }
             } catch (err) {
                 console.log('Retina Display Support Problem', err);
                 uber.width.set.call(this, width);


### PR DESCRIPTION
WebGL contexts don't have a `scale` method, which isn't currently a problem for Snap! itself but will be for extensions that use a 3D canvas...