### PR TITLE
better frame scheduling

### DIFF
--- a/snap.html
+++ b/snap.html
@@ -39,22 +39,31 @@
         <script>
             var world,
                 FPS = 67,
-                lastTime = 0;
+                lastIntendedTime = 0;
             window.onload = function () {
                 if ('serviceWorker' in navigator) {
                     navigator.serviceWorker.register('sw.js');
                 }
                 world = new WorldMorph(document.getElementById('world'));
                 new IDE_Morph().openIn(world);
-                loop();
+                requestAnimationFrame(loop);
             };
             function loop(timestamp) {
                 requestAnimationFrame(loop);
-                if (timestamp - lastTime < 1000 / FPS) {
+                if (timestamp - lastIntendedTime < 1000 / FPS) {
                     return;
                 }
                 world.doOneCycle();
-                lastTime = timestamp;
+                // browsers often cap framerate or just have some lag
+                // if the browser is keeping up, the intended time is incremented by a frame time (set to when this frame should've happened)
+                // this prevents accumulating error from latency
+
+                // if it's more than a frame behind, we don't want it to try and rush to catch up with many fast frames afterward
+                // so the last indended time is capped to be at most a frame behind
+                lastIntendedTime = Math.max(
+                    lastIntendedTime + 1000 / FPS,
+                    timestamp - 1000 / FPS
+                );
             }
         </script>
     </head>


### PR DESCRIPTION
project runs at 67 fps, and lets say someone has a high refresh rate monitor or just particular browser settings where an animation frame happens 75 times a second
previously it would only run a frame every 2 75ths of a second, which is only 37.5 fps, when it should be reaching at least 60

here frames can occasionally happen slightly faster than 67 times a second, but the average should be correct

note that lag or low framerates will still run slow