### PR TITLE
Allow cs10.org and bjc.berkeley.edu as valid extensions

### DIFF
--- a/src/extensions.js
+++ b/src/extensions.js
@@ -48,6 +48,8 @@ var SnapExtensions = {
     urls: [ // allow-list of trusted servers
         'libraries/',
         'https://snap.berkeley.edu/',
+        'https://bjc.berkeley.edu/',
+        'https://cs10.org/',
         'https://ecraft2learn.github.io/ai/', // Uni-Oxford, Ken Kahn
         'https://microworld.edc.org/' // EDC, E. Paul Goldenberg
     ]


### PR DESCRIPTION
This adds:
* https://cs10.org/
* https://bjc.berkeley.edu/

as authorized extensions domains.
I have full control over them (both are served via GitHub)
and will be able to take care of any issues.

This will help us / Dan have students develop extensions and features for CS10 without needing too many extra steps.