### PR TITLE
Checking langs and 'country langs' before uploading them

### DIFF
--- a/src/gui.js
+++ b/src/gui.js
@@ -7136,14 +7136,23 @@ IDE_Morph.prototype.languageMenu = function () {
 
 IDE_Morph.prototype.setLanguage = function (lang, callback, noSave) {
     var translation = document.getElementById('language'),
-        src = this.resourceURL('locale', 'lang-' + lang + '.js');
+        src;
     SnapTranslator.unload();
     if (translation) {
         document.head.removeChild(translation);
     }
+    if (!(lang in SnapTranslator.dict)) {
+        if (lang.includes('_') && lang.split('_')[0] in SnapTranslator.dict) {
+            lang = lang.split('_')[0];
+        } else {
+            lang = 'en';
+        }
+    }
     if (lang === 'en') {
         return this.reflectLanguage('en', callback, noSave);
     }
+
+    src = this.resourceURL('locale', 'lang-' + lang + '.js');
     translation = document.createElement('script');
     translation.id = 'language';
     translation.onload = () =>


### PR DESCRIPTION
Hi!

This simple PR checks "langs" before loading them.

If a lang does not exist (in Snap!), English is loaded and so,there are no "errors" nor "no found" requests.
If a lang does not exist but it is an "extra customization" (there are different lang_XX customizations, not only from different countries) of an already translated language, the "main" language is loaded.

This is interesting for all requests (also for direct URL constructions), but more important for Snap! plugins, where other environments (like Moodle, Wordpress...) have this really large llst of language support, and then, they try to lunch Snap! in those languages or sub-languages

Examples. Launching  Snap! with "de_CN", "de_AT"... causes "not found" requests and gets an English translation. With this PR these requests will get our German translation. Also, launching an not existing language translation, will get English translation (just like now) but avoiding "not found" requests.

Joan
