### PR TITLE
minor fix: use new URL format in Open in Community Site

### DIFF
--- a/src/cloud.js
+++ b/src/cloud.js
@@ -1122,7 +1122,7 @@ Cloud.prototype.removeEditorFromCollection = function (
 
 Cloud.prototype.showProjectPath = function (username, projectname) {
     return '/project?' + this.encodeDict({
-        user: username,
-        project: projectname
+        username: username,
+        projectname: projectname
     });
 };


### PR DESCRIPTION
Snap! still uses the old cloud project URL, which is still supported by the cloud for backwards compatibility, but we should really be using the new one. This fixes it.