### PR TITLE
Add copy / paste scripts

### DIFF
--- a/src/blocks.js
+++ b/src/blocks.js
@@ -3591,14 +3591,14 @@ BlockMorph.prototype.userMenu = function () {
     menu.addLine();
     if ((this instanceof CommandBlockMorph)) {
         menu.addItem(
-            'copy all',
+            'copy below',
             () => {
                 ide.clipboard = {
                     type: 'xml',
                     content: this.toXMLString()
                 };
             },
-            'send this block and all\nblocks underneath to the clipboard'
+            'copy block and below'
         );
     }
     menu.addItem(
@@ -3619,7 +3619,7 @@ BlockMorph.prototype.userMenu = function () {
             };
             block.destroy();
         },
-        'send this block to the clipboard'
+        'copy this block'
     );
     menu.addItem(
         'cut block',
@@ -3641,7 +3641,7 @@ BlockMorph.prototype.userMenu = function () {
 
             this.userDestroy();
         },
-        'send this block to the\nclipboard and it'
+        'copy this block and delete it'
     );
     menu.addLine();
     menu.addItem(
@@ -15702,7 +15702,7 @@ CommentMorph.prototype.userMenu = function () {
                 width: this.textWidth(),
             };
         },
-        'send this comment\nto the clipboard'
+        'copy this comment'
     );
     menu.addItem(
         'cut comment',
@@ -15715,7 +15715,7 @@ CommentMorph.prototype.userMenu = function () {
 
             this.userDestroy()
         },
-        'send this comment to the\nclipboard and delete this comment'
+        'copy this comment and delete it'
     );
     return menu;
 };

--- a/src/gui.js
+++ b/src/gui.js
@@ -3961,6 +3961,111 @@ IDE_Morph.prototype.removeBlock = function (aBlock, justThis) {
     aBlock.destroy(justThis);
 };
 
+// IDE_Morph copy / paste at hand
+
+IDE_Morph.prototype.copyUnderHand = function (event) {
+    var world = this.world();
+    var underHand,
+        hand,
+        mouseOverList;
+
+    hand = world.hand;
+    mouseOverList = hand.mouseOverList;
+
+    underHand = mouseOverList[0].parentThatIsA(BlockMorph) || 
+                mouseOverList[0].parentThatIsA(CommentMorph);
+
+    if (underHand && !underHand.isTemplate && !(underHand instanceof PrototypeHatBlockMorph)) {
+        let content = underHand.fullCopy();
+
+        if ((event === 'ctrl shift c') && (content instanceof CommandBlockMorph || content instanceof HatBlockMorph)) {
+            var nb = content.nextBlock();
+            if (nb) {
+                nb.destroy();
+            }
+        }
+
+        this.userCopy(content);
+
+    }
+}
+
+IDE_Morph.prototype.cutUnderHand = function () {
+    var world = this.world();
+    var underHand,
+        hand,
+        mouseOverList;
+
+    hand = world.hand;
+    mouseOverList = hand.mouseOverList;
+
+    underHand = mouseOverList[0].parentThatIsA(BlockMorph) || 
+                mouseOverList[0].parentThatIsA(CommentMorph);
+
+    if (underHand && !underHand.isTemplate && !(underHand instanceof PrototypeHatBlockMorph)) {
+        let content = underHand.fullCopy();
+
+        if (content instanceof CommandBlockMorph || content instanceof HatBlockMorph) {
+            var nb = content.nextBlock();
+            if (nb) {
+                nb.destroy();
+            }
+        }
+
+        this.userCopy(content);
+
+        underHand.userDestroy();
+    }
+}
+
+IDE_Morph.prototype.userCopy = function (content) {
+    if (content instanceof CommentMorph) {
+        this.clipboard = {
+            type: 'comment',
+            content: content.text(),
+            width: content.textWidth(),
+        }
+        return
+    }
+
+    if (content instanceof BlockMorph) {
+        content = content.fullCopy();
+
+        content.parent = this;
+        this.clipboard = {
+            type: 'xml',
+            content: content.toXMLString()
+        };
+        content.destroy();
+
+        return
+    }
+
+}
+
+IDE_Morph.prototype.userPaste = function (event) {
+    var world = this.world();
+
+    if (this.clipboard) {
+        switch (this.clipboard.type) {
+            case 'xml':
+                this.droppedText(this.clipboard.content);
+                break;
+            case 'comment':
+                let comment = new CommentMorph(this.clipboard.content);
+                if (this.clipboard.width) comment.setTextWidth(this.clipboard.width);
+                comment.pickUp(world);
+                world.hand.grabOrigin = {
+                    origin: this.palette,
+                    position: this.palette.center()
+                };
+                break;
+            default:
+                break;
+        }
+    }
+}
+
 // IDE_Morph menus
 
 IDE_Morph.prototype.userMenu = function () {

--- a/src/objects.js
+++ b/src/objects.js
@@ -9347,10 +9347,10 @@ StageMorph.prototype.processKeyEvent = function (event, action) {
                     (event.shiftKey ? 'shift ' : '') + keyName;
         }
     }
-    action.call(this, keyName);
+    action.call(this, keyName, event);
 };
 
-StageMorph.prototype.fireKeyEvent = function (key) {
+StageMorph.prototype.fireKeyEvent = function (key, event) {
     var evt = key.toLowerCase(),
         procs = [],
         ide = this.parentThatIsA(IDE_Morph);
@@ -9373,6 +9373,21 @@ StageMorph.prototype.fireKeyEvent = function (key) {
     if (evt === 'ctrl shift z' || (evt === 'ctrl y')) {
         if (!ide.isAppMode) {ide.currentSprite.scripts.redrop(); }
          return;
+    }
+    if (evt === 'ctrl shift c' || (evt === 'ctrl c')) {
+        ide.copyUnderHand(evt);
+        if (event != null) {
+            event.preventDefault();
+        }
+        return;
+    }
+    if (evt === 'ctrl x') {
+        ide.cutUnderHand();
+        return;
+    }
+    if (evt === 'ctrl v' || (evt === 'ctrl shift v')) {
+        ide.userPaste();
+        return;
     }
     if (evt === 'ctrl n') {
         if (!ide.isAppMode) {ide.createNewProject(); }


### PR DESCRIPTION
This is pretty much the same as my other pull request, but this time it's to the dev branch instead of master, and this time I didn't merge master into it (meaning the only files that were changed are the files I changed (I hope I did it right this time)).

This adds the ability to copy / paste scripts and comments. It works by setting a value to the block xml, which it then loads as if the user dropped a file into the script area. This makes sure that blocks are properly pasted, so if a custom block that doesn't exist in that scene or sprite, it creates the custom block. The only issue with this implementation is that when a user copies a custom block, then changes the custom block and then pastes, the custom block will be replaced by the old definition.

If you right click a block, there will be 3 new options:

- copy below
  - Copy this block and below
- copy block
  - Copy this block only
- cut block
  -  Copy this block, and delete it.

Comments also have new options

- copy comment
  - Copy this comment
- cut comment
  - Cut this comment

When you copy a comment, the width is also copies, so when you paste it, it stays the same width.

When you right click the editor area, there is a new option to paste (it only shows if you have already copied something).

There are also some keyboard shortcuts

- ctrl + c - copy all underneath mouse, or if it's a comment, just copy the comment.
- ctrl + shift + c - copy only this block or comment underneath mouse.
- ctrl + x - cut block or comment underneath the mouse.
- ctrl + v - paste whatever is in the clipboard.

I know this would make editing faster, because you don't have to drag blocks a very long distance now. You can just cut the script, then scroll to where you need the script, and paste (and it helps with accidentally dropping it in a c slot while dragging it up or down).

Again, the only issue with this is that when you copy a custom block, edit it, then paste, the definition will revert back to when you copied the block. I don't know of an elegant way of fixing this, as it would require modifying the `IDE_Morph.prototype.droppedText` function.

I am open to talking about this, and modifications. I don't think it would be best to merge this as it is currently, because I'm not sure if the function names should be renamed.