### PR TITLE
add noExitWarning to IDE config options

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -128,6 +128,7 @@ You can configure the looks and behavior of the IDE by passing it a configuratio
 |noRingify:	|bool	|disable/enable "ringify" / "unringify" in context menus|
 |noUserSettings:	|bool	|disable/enable persistent user preferences|
 |noDevWarning:	|bool	|ignore development version incompatibility warning|
+|noExitWarning:	|bool	|do not show a browser warning when closing the IDE with unsaved changes|
 |blocksZoom:	|num	|zoom factor for blocks, e.g. `1.5`|
 |blocksFade:	|num	|fading percentage for blocks, e.g. `85`|
 |zebra:	|num	|contrast percentage for nesting same-color blocks|

--- a/src/gui.js
+++ b/src/gui.js
@@ -420,7 +420,7 @@ IDE_Morph.prototype.openIn = function (world) {
             window.onbeforeunload = nop;
         }
         if (dict.noExitWarning) {
-            window.onbeforeunload = nop;
+            window.onbeforeunload = window.cachedOnbeforeunload;
         }
         if (dict.blocksZoom) {
             myself.savingPreferences = false;
@@ -896,6 +896,11 @@ IDE_Morph.prototype.applyConfigurations = function () {
     // disable cloud access
     if (cnf.noCloud) {
         this.cloud.disable();
+    }
+
+    // disable onbeforeunload close warning
+    if (cnf.noExitWarning) {
+        window.onbeforeunload = window.cachedOnbeforeunload;
     }
 };
 

--- a/src/morphic.js
+++ b/src/morphic.js
@@ -12469,7 +12469,11 @@ WorldMorph.prototype.initEventListeners = function () {
         false
     );
 
+    window.cachedOnbeforeunload = window.onbeforeunload;
     window.onbeforeunload = (evt) => {
+        if (window.cachedOnbeforeunload) {
+            window.cachedOnbeforeunload.call(null, evt);
+        }
         var e = evt || window.event,
             msg = "Are you sure you want to leave?";
         // For IE and Firefox


### PR DESCRIPTION
And make sure Morphic caches the previous value of `unbeforeuload` for those cases where Snap! is being embedded into a website that has its own `unbeforeunload` method defined and may not want us to overwrite it. In those cases, `noExitWarning` will restore the previous stored value.