### PR TITLE
More changes for UOC

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -129,9 +129,10 @@ You can configure the looks and behavior of the IDE by passing it a configuratio
 |noUserSettings:	|bool	|disable/enable persistent user preferences|
 |noDevWarning:	|bool	|ignore development version incompatibility warning|
 |noExitWarning:	|bool	|do not show a browser warning when closing the IDE with unsaved changes|
-|blocksZoom:	|num	|zoom factor for blocks, e.g. `1.5`|
-|blocksFade:	|num	|fading percentage for blocks, e.g. `85`|
-|zebra:	|num	|contrast percentage for nesting same-color blocks|
+|preserveTitle:	|bool	|do not set the tab title dynamically to reflect the current Snap! version|
+|blocksZoom:	|num	|zoom factor for blocks, e.g. `1.5`| |blocksFade:	|num
+|fading percentage for blocks, e.g. `85`| |zebra:	|num	|contrast percentage
+for nesting same-color blocks|
 
 Note that such configurations will not affect the user's own preference settings, e.g. configuring the blocks zoom or language will not overwrite the user's own settings which are kept in localstorage.
 

--- a/src/api.js
+++ b/src/api.js
@@ -55,20 +55,6 @@ modules.api = '2024-January-23';
     global variables
 */
 
-window.onmessage = function (event) {
-    // make the API accessible from outside an iframe
-    var ide = world.children[0];
-    if (!isNil(event.data.selector)) {
-        window.top.postMessage(
-            {
-                selector: event.data.selector,
-                response: ide[event.data.selector].apply(ide, event.data.params)
-            },
-            '*'
-        );
-    }
-};
-
 IDE_Morph.prototype.getScenes = function () {
     // return an array of all scenenames
     return this.scenes.itemsArray().map(each => each.name);

--- a/src/gui.js
+++ b/src/gui.js
@@ -346,6 +346,23 @@ IDE_Morph.prototype.init = function (config) {
 IDE_Morph.prototype.openIn = function (world) {
     var hash, myself = this;
 
+    window.onmessage = function (event) {
+        // make the API accessible from outside an iframe
+        var ide = world.children[0];
+        if (!isNil(event.data.selector)) {
+            window.top.postMessage(
+                {
+                    selector: event.data.selector,
+                    response: ide[event.data.selector].apply(
+                        ide,
+                        event.data.params
+                    )
+                },
+                '*'
+            );
+        }
+    };
+
     function initUser(username) {
         sessionStorage.username = username;
         myself.controlBar.cloudButton.refresh();

--- a/src/gui.js
+++ b/src/gui.js
@@ -254,6 +254,10 @@ function IDE_Morph(config = {}) {
         noRingify:      bool, disable/enable "ringify"/"unringify" in ctx menu
         noUserSettings: bool, disable/enable persistent user preferences
         noDevWarning:   bool, ignore development version incompatibility warning
+        noExitWarning:  bool, do not show a browser warning when closing the IDE
+                                with unsaved changes
+        preserveTitle:  bool, do not set the tab title dynamically to reflect
+                                the current Snap! version
         blocksZoom:     num, zoom factor for blocks, e.g. 1.5
         blocksFade:     num, fading percentage for blocks, e.g. 85
         zebra:          num, contrast percentage for nesting same-color blocks
@@ -1530,8 +1534,10 @@ IDE_Morph.prototype.createControlBar = function () {
         scene = myself.scenes.at(1) !== myself.scene ?
                 ' (' + myself.scene.name + ')' : '';
         name = (myself.getProjectName() || localize('untitled'));
-        document.title = "Snap! " +
-            (myself.getProjectName() ? name : SnapVersion);
+        if (!myself.config.preserveTitle) {
+            document.title = "Snap! " +
+                (myself.getProjectName() ? name : SnapVersion);
+        }
         txt = new StringMorph(
             prefix + name +  scene + suffix,
             14,

--- a/src/gui.js
+++ b/src/gui.js
@@ -352,7 +352,7 @@ IDE_Morph.prototype.openIn = function (world) {
 
     window.onmessage = function (event) {
         // make the API accessible from outside an iframe
-        var ide = world.children[0];
+        var ide = myself;
         if (!isNil(event.data.selector)) {
             window.top.postMessage(
                 {


### PR DESCRIPTION
When `preserveTitle` IDE config option is set, do not dynamically change the tab title to the current Snap! version. Useful for those who are embedding Snap! into their own websites and virtual campuses.

Additionally, move `window.onmessage` to `IDE_Morph` constructor so it doesn't depend on a global `world` var.

Updated `API.md` to reflect the new options.