### PR TITLE
Change "formating" to "formatting" in libraries window

### DIFF
--- a/libraries/LIBRARIES.json
+++ b/libraries/LIBRARIES.json
@@ -1716,7 +1716,7 @@
   },
   {
     "fileName": "textformat_module.xml",
-    "name": "Writing and formating",
+    "name": "Writing and formatting",
     "description": "Write text using fancy fonts, contributed by Tethrarxitet",
     "searchData": [
       "write _ size _ stats _",


### PR DESCRIPTION
Minor/grammatical change -- in the dev libraries window, the title of Tethrarxitet's fancy fonts library is titled "Writing and formating." "Formating" should be spelled "formatting."