### PR TITLE
Update embedMetadataPNG@morphic.js fix long script

### DIFF
--- a/src/morphic.js
+++ b/src/morphic.js
@@ -1631,7 +1631,7 @@ function embedMetadataPNG(aCanvas, aString) {
             embedTag
         );
     try {
-        bPart.splice(-12, 0, ...newChunk);
+        bPart = bPart.slice(0, -12).concat( newChunk.split(""), bPart.slice( -12));
         parts[1] = btoa(bPart.join(""));
     } catch (err) {
         console.log(err);


### PR DESCRIPTION
Fix the embedding of large >65kB scripts (XML). 
The spread (...) operator may cause stack overflow (Chrome@Win10). Replaced with the "slice/concat" sequence.
The problem is described on the Snap forum. https://forum.snap.berkeley.edu/t/some-smart-script-pics-arent-working/17230