### PR TITLE
Fix "delete block _" block in spanish translation

### DIFF
--- a/locale/lang-es.js
+++ b/locale/lang-es.js
@@ -891,7 +891,7 @@ SnapTranslator.dict.es = {
     "delete _ of _": "borrar _ de _",
     "delete a category...": "eliminar una categoría…",
     "delete block": "eliminar bloque",
-    "delete block _": "eliminar bloque",
+    "delete block _": "eliminar bloque _",
     "delete block definition...": "eliminar definición de bloque…",
     "delete slot": "eliminar una ranura",
     "delete solution": "eliminar solución",


### PR DESCRIPTION
The delete block _ had no inputs in the spanish translation