### PR TITLE
Error types and try-catch support for them(feature)

### DIFF
--- a/src/extensions.js
+++ b/src/extensions.js
@@ -368,6 +368,11 @@ SnapExtensions.primitives.set(
 SnapExtensions.primitives.set(
     'err_error(msg)',
     function (msg) {
+        if (msg instanceof List){
+            var err = new Error(msg.at(2));
+            err.name = msg.at(1);
+            throw err
+        }
         throw new Error(msg, {cause: 'user'});
     }
 );

--- a/src/extensions.js
+++ b/src/extensions.js
@@ -369,7 +369,7 @@ SnapExtensions.primitives.set(
     'err_error(msg)',
     function (msg) {
         if (msg instanceof List){
-            var err = new Error(msg.at(2));
+            var err = new Error(msg.at(2),{cause: 'user'});
             err.name = msg.at(1);
             throw err
         }

--- a/src/threads.js
+++ b/src/threads.js
@@ -1321,7 +1321,7 @@ Process.prototype.tryCatch = function (action, exception, errVarName) {
         }
         exception.pc = 0;
         exception.outerContext.variables.addVar(errVarName);
-        exception.outerContext.variables.setVar(errVarName, new List(error.name,error.message));
+        exception.outerContext.variables.setVar(errVarName, error.name==='Error'?error.message:new List(error.name,error.message));
         this.context = exception;
         this.evaluate(next, new List(), true);
     };

--- a/src/threads.js
+++ b/src/threads.js
@@ -1321,7 +1321,7 @@ Process.prototype.tryCatch = function (action, exception, errVarName) {
         }
         exception.pc = 0;
         exception.outerContext.variables.addVar(errVarName);
-        exception.outerContext.variables.setVar(errVarName, error.name==='Error'?error.message:new List(error.name,error.message));
+        exception.outerContext.variables.setVar(errVarName, error.name==='Error'?error.message:new List([error.name,error.message]));
         this.context = exception;
         this.evaluate(next, new List(), true);
     };

--- a/src/threads.js
+++ b/src/threads.js
@@ -1321,7 +1321,7 @@ Process.prototype.tryCatch = function (action, exception, errVarName) {
         }
         exception.pc = 0;
         exception.outerContext.variables.addVar(errVarName);
-        exception.outerContext.variables.setVar(errVarName, error.message);
+        exception.outerContext.variables.setVar(errVarName, new List(error.name,error.message));
         this.context = exception;
         this.evaluate(next, new List(), true);
     };


### PR DESCRIPTION
https://forum.snap.berkeley.edu/t/please-add-custom-error-types/19318/11
I'll stop with the typed error pull making here
![image](https://github.com/user-attachments/assets/7563482f-72f6-4a29-94e8-96786063b25b)

when the error name is "Error", the trycatch block passes the error message instead of both its name and message to the catch code.
when the input to the error block isn't a list, it uses "Error" as the name.
both the trycatch block and the error block uses a list which is: the name and, the message.

js funct blocks won't work when off