### PR TITLE
Fixing serial connection closing function

### DIFF
--- a/src/extensions.js
+++ b/src/extensions.js
@@ -1605,8 +1605,6 @@ SnapExtensions.primitives.set(
             }
             return;
         }
-        proc.pushContext('doYield');
-        proc.pushContext();
     }
 );
 


### PR DESCRIPTION
Hi Jens.

Bernat and Jose told me yesterday microblocks library had some USB connections issues.

I've been testing and:
 - Connecting by USB is running ok for me.
 - Closing is not running. I see that deleting its "yield" is the solution, because the assync closing function.

Maybe you want to check if this acction could cause other problems... but I've been testing and I haven't seen any issues.

Joan