### PR TITLE
Improved Unicode Support for Strings

### DIFF
--- a/src/threads.js
+++ b/src/threads.js
@@ -5564,7 +5564,7 @@ Process.prototype.reportUnicode = function (string) {
             return string.map(each => this.reportUnicode(each));
         }
         str = isNil(string) ? '\u0000' : string.toString();
-        unicodeList = Array.from(str);
+        unicodeList = this.safeStringArray(str);
         if (unicodeList.length > 1) {
             return this.reportUnicode(new List(unicodeList));
         }
@@ -5647,7 +5647,7 @@ Process.prototype.reportBasicTextSplit = function (string, delimiter) {
         break;
     case '':
     case 'letter':
-        return new List(Array.from(str));
+        return new List(this.safeStringArray(str));
     case 'csv':
         return this.parseCSV(string);
     case 'json':

--- a/src/threads.js
+++ b/src/threads.js
@@ -5506,14 +5506,15 @@ Process.prototype.reportBasicLetter = function (idx, string) {
     var str, i;
 
     str = isNil(string) ? '' : string.toString();
+    char_array = Array.from(str);
     if (this.inputOption(idx) === 'random') {
-        idx = this.reportBasicRandom(1, str.length);
+        idx = this.reportBasicRandom(1, char_array.length);
     }
     if (this.inputOption(idx) === 'last') {
-        idx = str.length;
+        idx = char_array.length;
     }
     i = +(idx || 0);
-    return str[i - 1] || '';
+    return char_array[i - 1] || '';
 };
 
 Process.prototype.reportTextAttribute = function (choice, text) {
@@ -5538,11 +5539,8 @@ Process.prototype.reportTextAttribute = function (choice, text) {
 
 Process.prototype.reportStringSize = function (data) {
     return this.hyper(
-        str => isString(str) ? str.length
+        str => isString(str) ? Array.from(str.toString()).length
                 : (parseFloat(str) === +str ? str.toString().length : 0),
-        // proposed scheme by Michael to address text with emojis, has
-        // memory issue when the stringd get very large:
-        // str => isNil(data) ? 0 : Array.from(str.toString()).length,
         data
     );
 };
@@ -5557,8 +5555,7 @@ Process.prototype.reportUnicode = function (string) {
             return string.map(each => this.reportUnicode(each));
         }
         str = isNil(string) ? '\u0000' : string.toString();
-        // unicodeList = Array.from(str); // emoji-friendly version
-        unicodeList = str.split('');
+        unicodeList = Array.from(str);
         if (unicodeList.length > 1) {
             return this.reportUnicode(new List(unicodeList));
         }
@@ -5641,8 +5638,7 @@ Process.prototype.reportBasicTextSplit = function (string, delimiter) {
         break;
     case '':
     case 'letter':
-        // return new List(Array.from(str)); // proposed by Michael for emojis
-        return new List(str.split(''));
+        return new List(Array.from(str));
     case 'csv':
         return this.parseCSV(string);
     case 'json':
@@ -8800,7 +8796,7 @@ Process.prototype.slotType = function (spec) {
         'cs':           5, // spec
         // mnemonics:
         'script':       5,
-        
+
         '6':            6,
         'cmdring':      6, // spec
         // mnemonics:
@@ -9288,7 +9284,7 @@ Process.prototype.doSetBlockAttribute = function (attribute, block, val) {
     while (rcvr.doubleDefinitionsFor(def).length > 0) {
         def.spec += (' (2)');
     }
-    
+
     // update all block instances:
     // refer to "updateDefinition()" of BlockEditorMorph:
     template = rcvr.paletteBlockInstance(def);
@@ -10534,7 +10530,7 @@ JSCompiler.prototype.gensymForVar = function (varName, argIndex) {
 
 JSCompiler.prototype.getGensym = function (varName) {
     var scope = this.scope, gensym;
-    while (null == (gensym = scope.get(varName)) && 
+    while (null == (gensym = scope.get(varName)) &&
         null != (scope = scope.outerScope));
     return gensym;
 };
@@ -10592,7 +10588,7 @@ JSCompiler.prototype.compileFunctionBody = function (
     if (block instanceof Array) {
         throw new Error('can\'t compile empty ring');
     }
-   
+
     this.source = aContext;
     if (implicitParamCount === '' || isNil(implicitParamCount)) {
         this.implicitParams = 1;

--- a/src/threads.js
+++ b/src/threads.js
@@ -5502,11 +5502,20 @@ Process.prototype.reportLetter = function (idx, string) {
     );
 };
 
+Process.prototype.safeStringArray = function (str) {
+    // An error is thrown if the string is >= 125814709 characters long
+    str = (str || '').toString();
+    if (str.length > 125814709) {
+        return str;
+    }
+    return Array.from(str.toString());
+};
+
 Process.prototype.reportBasicLetter = function (idx, string) {
     var str, i;
 
     str = isNil(string) ? '' : string.toString();
-    char_array = Array.from(str);
+    char_array = this.safeStringArray(str);
     if (this.inputOption(idx) === 'random') {
         idx = this.reportBasicRandom(1, char_array.length);
     }
@@ -5539,7 +5548,7 @@ Process.prototype.reportTextAttribute = function (choice, text) {
 
 Process.prototype.reportStringSize = function (data) {
     return this.hyper(
-        str => isString(str) ? Array.from(str.toString()).length
+        str => isString(str) ? this.safeStringArray(str).length
                 : (parseFloat(str) === +str ? str.toString().length : 0),
         data
     );

--- a/src/threads.js
+++ b/src/threads.js
@@ -5503,9 +5503,13 @@ Process.prototype.reportLetter = function (idx, string) {
 };
 
 Process.prototype.safeStringArray = function (str) {
-    // An error is thrown if the string is >= 125814709 characters long
+    // An error is thrown if the string is > 125814708 characters long
+    // While both strings and arrays can be much longer, the JS runtime
+    // throws an error when using a string iterator which is too long.
+    // We set this value at an "even" 100 million characters.
+    MAX_STRING_LENGTH = 100e6;
     str = (str || '').toString();
-    if (str.length > 125814709) {
+    if (str.length > MAX_STRING_LENGTH) {
         return str;
     }
     return Array.from(str.toString());


### PR DESCRIPTION
This improves all string-type blocks to use ES6 / ES2015+ `Array.from` to get Unicode code points for each "character" of a string rather than each byte. 

I've added a `safeStringArray` which prevents the error that Ken ran into before, so extremely large strings are still handled decently well. This means that the return value can be _either_ a string or (JavaScript) array, but that should be fine.