### PR TITLE
Correct minor typographical error in pyret/inline.html

### DIFF
--- a/pyret/inline.html
+++ b/pyret/inline.html
@@ -154,7 +154,7 @@
         <a href="https://www.pyret.org/">Pyret</a> programming language
         in the fabulous <a href="https://bootstrapworld.org/">Bootstrap</a>
         curriculum (be sure to check it out if haven't already!).</p>
-        <p>If you see this page it's very likey that it doesn't yet do anything
+        <p>If you see this page it's very likely that it doesn't yet do anything
         or that it isn't even operational and throws a bazillion errors. We use
         it together with our friends over at Bootstrap to internally try stuff
         as we're testing some wild ideas. So please don't yet inquire about


### PR DESCRIPTION
I discovered a small typo in the file `inline.html` of the `pyret` directory while working on an experimental _Snap!_ modification.

This fix does not change the functionality of _Snap!_ and is not critical by any means.