### PR TITLE
[BROKEN - DO NOT MERGE] Add basic quadratics solver library

### DIFF
--- a/libraries/LIBRARIES.json
+++ b/libraries/LIBRARIES.json
@@ -28,6 +28,18 @@
     }
   },
   {
+    "fileName": "quadratics.xml",
+    "name": "Quadratics",
+    "description": "Handling quadratic equations in mathematics.",
+    "searchData": [
+    ],
+    "categories": [
+      "operators"
+    ],
+    "translations": {
+    }
+  },
+  {
     "fileName": "OOP_module.xml",
     "name": "OOP",
     "description": "Data Objects with prototypical inheritance",


### PR DESCRIPTION
This is a pull request to add the `Quadratics` library for Snap!, written entirely using Snap!'s GUI functionality.

I created the aforementioned library to help solve quadratic equations ([learn more](https://en.wikipedia.org/wiki/Quadratic_equation)) in the form `ax2+bx+c=0`, using `a`, `b`, and `c` as parameters.

In order to allow for the usage of complex numbers in calculations, the library will automatically setup the complex numbers library as needed.

Some of the blocks provided with this library:
![image](https://github.com/user-attachments/assets/820a5ff5-9d2d-4161-b21d-f36f21a4fd54)

_Note: I wrote this library in a slightly modified Snap! 10.2.5, but I've found that it works on the latest unmodified builds as well._