### PR TITLE
add scale slider for performer mode

### DIFF
--- a/src/gui.js
+++ b/src/gui.js
@@ -4686,8 +4686,7 @@ IDE_Morph.prototype.settingsMenu = function () {
         menu.addItem(
             'Performer mode scale...',
             'userSetPerformerModeScale',
-            'specify the scale of the stage\npixels in performer mode',
-            new Color(100, 0, 0)
+            'specify the scale of the stage\npixels in performer mode'
         );
     }
     menu.addLine(); // everything visible below is persistent

--- a/src/gui.js
+++ b/src/gui.js
@@ -350,6 +350,7 @@ IDE_Morph.prototype.init = function (config) {
     this.paletteWidth = 200; // initially same as logo width
     this.stageRatio = 1; // for IDE animations, e.g. when zooming
     this.performerMode = false;
+    this.performerScale = 1;
 
     this.wasSingleStepping = false; // for toggling to and from app mode
 
@@ -2675,13 +2676,17 @@ IDE_Morph.prototype.fixLayout = function (situation) {
             this.stageRatio = 1;
             this.isSmallStage = false;
             this.stage.dimensions = new Point(
-                    this.width() - this.palette.width(),
-                    this.palette.height() -
+                    (this.width() - this.palette.width()) / this.performerScale,
+                    (this.palette.height() -
                         this.corralBar.height() -
                         this.corral.childThatIsA(SpriteIconMorph).height()
+                    ) / this.performerScale
             );
             this.stage.stopVideo();
-            this.stage.setExtent(this.stage.dimensions);
+            this.stage.setExtent(new Point(
+                this.stage.dimensions.x * this.performerScale,
+                this.stage.dimensions.y * this.performerScale
+            ));
             this.stage.resizePenTrails();
             Costume.prototype.maxDimensions = this.stage.dimensions;
             this.paletteHandle.fixLayout();
@@ -4677,6 +4682,14 @@ IDE_Morph.prototype.settingsMenu = function () {
         'check to have the stage use up\nall space and go behind the\n' +
         'scripting area'
     );
+    if (this.performerMode) {
+        menu.addItem(
+            'Performer mode scale...',
+            'userSetPerformerModeScale',
+            'specify the scale of the stage\npixels in performer mode',
+            new Color(100, 0, 0)
+        );
+    }
     menu.addLine(); // everything visible below is persistent
     addPreference(
         'Blurred shadows',
@@ -7471,6 +7484,29 @@ IDE_Morph.prototype.setEmbedMode = function () {
     this.add(this.embedPlayButton);
 
     this.fixLayout();
+};
+
+IDE_Morph.prototype.userSetPerformerModeScale = function () {
+   new DialogBoxMorph(
+        this,
+        num => {
+            this.performerScale = Math.min(Math.max(+num, 1), 32);
+            this.parentThatIsA(IDE_Morph).fixLayout();
+        },
+        this
+    ).prompt(
+        "Performer mode scale",
+        this.performerScale.toString(),
+        this.world(),
+        null, // pic
+        null, // choices
+        null, // read only
+        true, // numeric
+        1,    // slider min
+        32,   // slider max
+        nop,  // slider action
+        0     // decimals
+    );
 };
 
 IDE_Morph.prototype.toggleAppMode = function (appMode) {

--- a/src/objects.js
+++ b/src/objects.js
@@ -3243,13 +3243,15 @@ SpriteMorph.prototype.fixLayout = function () {
         corners = [],
         origin,
         corner,
-        costumeExtent;
+        costumeExtent,
+        ide = this.parentThatIsA(IDE_Morph);
 
     currentCenter = this.center();
     isLoadingCostume = this.costume &&
         typeof this.costume.loaded === 'function';
     stageScale = this.parent instanceof StageMorph ?
             this.parent.scale : 1;
+    if (ide?.performerMode) { stageScale = ide.performerScale; }
     facing = this.rotationStyle ? this.heading : 90;
     if (this.rotationStyle === 2) {
         facing = 90;
@@ -3349,12 +3351,14 @@ SpriteMorph.prototype.render = function (ctx) {
         cst,
         pic, // (flipped copy of) actual costume based on my rotation style
         stageScale,
-        handle;
+        handle,
+        ide = this.parentThatIsA(IDE_Morph);
 
     isLoadingCostume = this.costume &&
         typeof this.costume.loaded === 'function';
     stageScale = this.parent instanceof StageMorph ?
             this.parent.scale : 1;
+    if (ide?.performerMode) { stageScale = ide.performerScale; }
     facing = this.rotationStyle ? this.heading : 90;
     if (this.rotationStyle === 2) {
         facing = 90;
@@ -6493,7 +6497,9 @@ SpriteMorph.prototype.neighbors = function (aStage) {
 SpriteMorph.prototype.perimeter = function (aStage) {
     var stage = aStage || this.parentThatIsA(StageMorph),
         stageScale = this instanceof StageMorph ? 1 : stage.scale,
-        radius;
+        radius,
+        ide = this.parentThatIsA(IDE_Morph);
+    if (ide?.performerMode) { stageScale = ide.performerScale; }
     if (this.costume) {
         radius = Math.max(
             this.costume.width(),
@@ -6600,7 +6606,8 @@ SpriteMorph.prototype.blitOn = function (target, mask = 'source-atop') {
         relRot, relScale, stageScale,
         centerDist, centerDelta, centerAngleRadians, center,
         originDist, originAngleRadians,
-        spriteCenter, thisCenter, relPos, pos;
+        spriteCenter, thisCenter, relPos, pos,
+        ide = this.parentThatIsA(IDE_Morph);
 
     // prevent pasting an object onto itself
     if (this === target) {return; }
@@ -6628,6 +6635,7 @@ SpriteMorph.prototype.blitOn = function (target, mask = 'source-atop') {
             relRot = sourceHeading - targetHeading;
             relScale = this.scale / target.scale;
             stageScale = this.parentThatIsA(StageMorph).scale;
+            if (ide?.performerMode) { stageScale = ide.performerScale; }
             centerDist = target.center().distanceTo(this.center());
             centerDelta = this.center().subtract(target.center());
             centerAngleRadians = Math.atan2(centerDelta.y, centerDelta.x);
@@ -7217,9 +7225,14 @@ SpriteMorph.prototype.positionTalkBubble = function () {
         stageScale = stage ? stage.scale : 1,
         bubble = this.talkBubble(),
         bottom = this.bottom(),
-        step = this.extent().divideBy(10)
-            .max(new Point(5, 5).scaleBy(stageScale))
-            .multiplyBy(new Point(-1, 1));
+        step,
+        ide = this.parentThatIsA(IDE_Morph);
+
+    if (ide?.performerMode) { stageScale = ide.performerScale; }
+
+    step = this.extent().divideBy(10)
+        .max(new Point(5, 5).scaleBy(stageScale))
+        .multiplyBy(new Point(-1, 1));
 
     if (!bubble) {return null; }
     bubble.show();
@@ -7291,7 +7304,10 @@ SpriteMorph.prototype.drawLine = function (start, dest) {
         to = dest.subtract(stagePos).divideBy(stageScale),
         damagedFrom,
         damagedTo,
-        damaged;
+        damaged,
+        ide = this.parentThatIsA(IDE_Morph);
+
+    if (ide?.performerMode) { stageScale = ide.performerScale; }
 
     if (this.isDown) {
         // record for later svg conversion


### PR DESCRIPTION
In performer mode the stage takes up all of the scripting area, thus some operations such as hyper-creating costumes get extremely costly.

This PR adds a gear-menu option to set the scale of the stage.

Usage example with a scale of 10 and a super costly hyper-operation:

https://github.com/user-attachments/assets/511876b4-920a-4a48-b3a9-e15137a704bf