### PR TITLE
Fixing noExitWarning flag/configuration feature

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,7 +4,7 @@
 
 ### 2025-09-06
 * blocks: fixed & added "senders / receivers" scanning support for "request" reporters
-
+* morphic and gui: fixed noExitWarning configuration/flag feature
 ### 2025-09-05
 * neural networks library: Added dynamic dropdown menu to the "tag" input of the "generate predicate" block
 * objects: fixed a doubling "corpse" bug when deleting a cloned permanent "Turtle sprite"

--- a/snap.html
+++ b/snap.html
@@ -13,14 +13,14 @@
         <meta name="mobile-web-app-title" content="Snap!">
         <meta name="msapplication-TileImage" content="img/snap-icon-144.png">
         <meta name="msapplication-TileColor" content="#FFFFFF">
-        <script src="src/morphic.js?version=2025-03-20"></script>
+        <script src="src/morphic.js?version=2025-09-06"></script>
         <script src="src/symbols.js?version=2024-11-24"></script>
         <script src="src/widgets.js?version=2025-03-17"></script>
         <script src="src/blocks.js?version=2025-09-06"></script>
         <script src="src/threads.js?version=2025-08-29"></script>
         <script src="src/objects.js?version=2025-09-05"></script>
         <script src="src/scenes.js?version=2024-05-28"></script>
-        <script src="src/gui.js?version=2025-08-29"></script>
+        <script src="src/gui.js?version=2025-09-06"></script>
         <script src="src/paint.js?version=2023-05-24"></script>
         <script src="src/lists.js?version=2025-06-12"></script>
         <script src="src/byob.js?version=2025-05-13"></script>

--- a/src/gui.js
+++ b/src/gui.js
@@ -87,7 +87,7 @@ HatBlockMorph*/
 
 // Global stuff ////////////////////////////////////////////////////////
 
-modules.gui = '2025-August-29';
+modules.gui = '2025-September-06';
 
 // Declarations
 
@@ -469,10 +469,10 @@ IDE_Morph.prototype.openIn = function (world) {
         }
         if (dict.hideControls) {
             myself.controlBar.hide();
-            window.onbeforeunload = nop;
+            window.noExitWarning = true;
         }
         if (dict.noExitWarning) {
-            window.onbeforeunload = window.cachedOnbeforeunload;
+            window.noExitWarning = true;
         }
         if (dict.blocksZoom) {
             myself.savingPreferences = false;
@@ -966,7 +966,7 @@ IDE_Morph.prototype.applyConfigurations = function () {
 
     // disable onbeforeunload close warning
     if (cnf.noExitWarning) {
-        window.onbeforeunload = window.cachedOnbeforeunload;
+        window.noExitWarning = true;
     }
 };
 
@@ -977,7 +977,7 @@ IDE_Morph.prototype.applyPaneHidingConfigurations = function () {
     if (cnf.hideControls) {
         this.logo.hide();
         this.controlBar.hide();
-        window.onbeforeunload = nop;
+        window.noExitWarning = true;
     }
 
     // hide categories

--- a/src/morphic.js
+++ b/src/morphic.js
@@ -1351,7 +1351,7 @@
 
 /*jshint esversion: 11, bitwise: false*/
 
-var morphicVersion = '2025-March-20';
+var morphicVersion = '2025-September-06';
 var modules = {}; // keep track of additional loaded modules
 var useBlurredShadows = true;
 
@@ -12452,22 +12452,14 @@ WorldMorph.prototype.initEventListeners = function () {
         false
     );
 
-    window.cachedOnbeforeunload = window.onbeforeunload;
     this.onbeforeunloadListener = (evt) => {
-        if (!this.hasUnsavedEdits()) return;
-        if (window.cachedOnbeforeunload) {
-            window.cachedOnbeforeunload.call(null, evt);
+        if (this.hasUnsavedEdits() && !window.noExitWarning) {
+            evt.preventDefault();
+            // legacy browsers support
+            evt.returnValue = true;
         }
-        var e = evt || window.event,
-            msg = "Are you sure you want to leave?";
-        // For IE and Firefox
-        if (e) {
-            e.returnValue = msg;
-        }
-        // For Safari / chrome
-        return msg;
     };
-     window.addEventListener("beforeunload", this.onbeforeunloadListener);
+    window.addEventListener("beforeunload", this.onbeforeunloadListener);
 };
 
 WorldMorph.prototype.hasUnsavedEdits = function () {


### PR DESCRIPTION
Hi Jens!

I saw noExitWarning flag didn't work
Then, I also saw that current JS onbeforeunload  implementation had different changes. Now, changing the warning message is not possible (not without a custom implementation, disabling the browser feature and creating you own "modal").

So, I fix our current operation in a simple way: using a ` window.noExitWarning`  flag,  checking in our "beforeunload" listener if `(this.hasUnsavedEdits() && !window.noExitWarning)` and using the current allowed instructions there.

Joan