### PR TITLE
Upstream/a11y toggle feat(a11y): improve checkbox/radio visibility in Bright theme

### DIFF
--- a/src/widgets.js
+++ b/src/widgets.js
@@ -1124,6 +1124,8 @@ ToggleMorph.prototype.init = function (
     if (IDE_Morph && IDE_Morph.prototype && IDE_Morph.prototype.isBright) {
         this.outlineColor = new Color(120, 120, 120);
         this.outlineGradient = false;
+        // slightly darker fill than panel background for clearer contrast
+        this.color = new Color(210, 210, 210);
     }
     this.fixLayout();
     this.refresh();
@@ -1188,12 +1190,14 @@ ToggleMorph.prototype.createLabel = function () {
         }
     }
     if (this.tick === null) {
-        var tickColor = (IDE_Morph && IDE_Morph.prototype && IDE_Morph.prototype.isBright)
-            ? IDE_Morph.prototype.buttonLabelColor || new Color(70, 70, 70)
-            : new Color(240, 240, 240);
+        var isBright = (IDE_Morph && IDE_Morph.prototype && IDE_Morph.prototype.isBright),
+            tickColor = isBright
+                ? IDE_Morph.prototype.buttonLabelColor || new Color(70, 70, 70)
+                : new Color(240, 240, 240),
+            tickSize = this.fontSize + (isBright ? 2 : 0); // enlarge tick a bit in bright mode
         this.tick = new StringMorph(
             localize(this.labelString),
-            this.fontSize,
+            tickSize,
             this.fontStyle,
             true,
             false,

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -1120,6 +1120,11 @@ ToggleMorph.prototype.init = function (
         environment,
         hint
     );
+    // increase contrast for checkboxes/radio in bright theme for accessibility
+    if (IDE_Morph && IDE_Morph.prototype && IDE_Morph.prototype.isBright) {
+        this.outlineColor = new Color(120, 120, 120);
+        this.outlineGradient = false;
+    }
     this.fixLayout();
     this.refresh();
 };
@@ -1183,6 +1188,9 @@ ToggleMorph.prototype.createLabel = function () {
         }
     }
     if (this.tick === null) {
+        var tickColor = (IDE_Morph && IDE_Morph.prototype && IDE_Morph.prototype.isBright)
+            ? IDE_Morph.prototype.buttonLabelColor || new Color(70, 70, 70)
+            : new Color(240, 240, 240);
         this.tick = new StringMorph(
             localize(this.labelString),
             this.fontSize,
@@ -1191,7 +1199,7 @@ ToggleMorph.prototype.createLabel = function () {
             false,
             false,
             shading ? new Point(1, 1) : null,
-            new Color(240, 240, 240)
+            tickColor
         );
         this.add(this.tick);
     }


### PR DESCRIPTION
- 变更动机
- 明亮外观下复选框/单选框在白底上对比度不足，非悬停状态难以辨认。提升视觉可访问性以满足常见对比度建议。
- 变更内容
- src/widgets.js （仅此文件）
  - 在 Bright 主题中为 ToggleMorph 使用更深的边框色，关闭边框渐变。
  - 填充色略深于面板背景以形成更清晰的盒子轮廓。
  - 勾选符号和单选圆点采用按钮文字色（深灰），在 Bright 模式将字号加大 2pt。
  - Dark 主题不受影响；未更改交互或逻辑。
- 范围控制
- 不包含任何新脚本或工具、文档或生成产物。
- - 测试说明
- 切换到 Bright 主题，检查设置菜单、画板与变量面板中的复选框/单选框的可见性。
- 切回 Dark 主题，确认视觉保持原样（无回归）。
- 影响文件
- M src/widgets.js