### PR TITLE
Upstream/i18n devwarn fix(i18n): localize and delay Dev Warning until language is loaded

### DIFF
--- a/src/gui.js
+++ b/src/gui.js
@@ -299,6 +299,7 @@ IDE_Morph.prototype.init = function (config) {
     this.serializer = new SnapSerializer();
     this.config = config;
     this.version = Date.now(); // for outside observers
+    this.devWarned = false; // ensure dev warning shown once and after i18n ready
 
     // restore saved user preferences
     this.userLanguage = null; // user language preference for startup
@@ -7927,6 +7928,10 @@ IDE_Morph.prototype.reflectLanguage = function (lang, callback, noSave) {
     var projectData,
         urlBar = location.hash;
     SnapTranslator.language = lang;
+    // ensure dev warning after language set
+    if (!this.devWarned) {
+        this.warnAboutDev();
+    }
     if (!this.loadNewProject) {
         this.scene.captureGlobalSettings();
         if (Process.prototype.isCatchingErrors) {
@@ -9106,6 +9111,7 @@ IDE_Morph.prototype.warnAboutDev = function () {
     if (!SnapVersion.includes('-dev') || this.config.noDevWarning) {
         return;
     }
+    if (this.devWarned) { return; }
     this.inform(
         localize("CAUTION! Development Version"),
         localize(
@@ -9118,6 +9124,7 @@ IDE_Morph.prototype.warnAboutDev = function () {
             'for the official Snap! installation.'
         )
     ).nag = true;
+    this.devWarned = true;
 };
 
 // IDE_Morph tutorial scene

--- a/src/gui.js
+++ b/src/gui.js
@@ -9107,14 +9107,16 @@ IDE_Morph.prototype.warnAboutDev = function () {
         return;
     }
     this.inform(
-        "CAUTION! Development Version",
-        'This version of Snap! is being developed.\n' +
+        localize("CAUTION! Development Version"),
+        localize(
+            'This version of Snap! is being developed.\n' +
             '*** It is NOT supported for end users. ***\n' +
             'Saving a project in THIS version is likely to\n' +
             'make it UNUSABLE or DEFECTIVE for current and\n' +
             'even future official versions!\n\n' +
             'visit https://snap.berkeley.edu/run\n' +
             'for the official Snap! installation.'
+        )
     ).nag = true;
 };
 


### PR DESCRIPTION
变更动机
启动早期弹窗在语言脚本加载前显示，造成初次出现英文；需要本地化并延后到语言就绪后显示，避免“英文闪现”。
变更内容
src/gui.js（仅此文件）
对警示弹窗的标题与正文显式 localize(...)。
在 reflectLanguage() 设置语言后再触发 warnAboutDev()；若目标语言非英文或字典未就绪则推迟展示。
范围控制
不包含任何新脚本或工具、文档或生成产物。
风险评估
低（仅影响启动阶段的弹窗显示时机与文案）。
测试说明
访问 snap.html#lang:zh_CN：启动后弹窗为中文且在语言加载后显示。
不加语言锚点时无异常；其它功能不受影响。
影响文件
M src/gui.js
参考说明
行为未变更，仅优化显示时机与本地化。