### PR TITLE
i18n(zh_CN): add translations for Dev Warning, Dynamic scheduling (and hints), Performer mode scale, and paint hint

### DIFF
--- a/locale/lang-zh_CN.js
+++ b/locale/lang-zh_CN.js
@@ -1575,3 +1575,15 @@ SnapTranslator.dict.zh_CN = { ...SnapTranslator.dict.zh_CN,
     "your own": "你自己",
     "z": "z"
 };
+
+// zh_CN additions for visible UI strings (kept minimal for upstream)
+SnapTranslator.dict.zh_CN = { ...SnapTranslator.dict.zh_CN,
+    "CAUTION! Development Version": "注意！开发版本",
+    "This version of Snap! is being developed.\n*** It is NOT supported for end users. ***\nSaving a project in THIS version is likely to\nmake it UNUSABLE or DEFECTIVE for current and\neven future official versions!\n\nvisit https://snap.berkeley.edu/run\nfor the official Snap! installation.": "当前 Snap! 处于开发版本。\n*** 本版本不面向终端用户。***\n在此版本中保存的项目很可能\n无法在当前或未来的正式版本中正常使用或会出现缺陷！\n\n请访问 https://snap.berkeley.edu/run\n获取官方 Snap! 安装与运行入口。",
+    "Dynamic scheduling": "动态调度",
+    "uncheck to schedule\nthreads framewise": "取消勾选后以逐帧方式调度线程",
+    "check to quickstep\nthreads atomically": "勾选后以原子快速步进方式调度线程",
+    "Performer mode scale...": "演示模式缩放...",
+    "specify the scale of the stage\npixels in performer mode": "设置演示模式下舞台像素缩放比例",
+    "Constrain proportions of shapes?\n(you can also hold shift)": "只画正方形/圆形/垂直或水平线\n(相当于按住shift键)"
+};


### PR DESCRIPTION
- 变更动机
- 补齐与上述改动对应的中文资源键；精确匹配源码字符串，减少早期英文显示并提升设置/画板的中文覆盖。
- 变更内容
- locale/lang-zh_CN.js （仅此文件）
  - 开发版警示弹窗标题与整段正文（保留换行与空格）。
  - 设置项与提示： Dynamic scheduling 、 uncheck to schedule\nthreads framewise 、 check to quickstep\nthreads atomically 。
  - 设置项与提示： Performer mode scale... 、 specify the scale of the stage\npixels in performer mode 。
  - 画板提示： Constrain proportions of shapes?\n(you can also hold shift) （无空格版本以确保命中）。
- 范围控制
- 不提交任何新脚本或工具、文档或生成产物。
- 风险评估
- 极低（新增键不影响其它语言与逻辑；长文案保留原格式）。
- 测试说明
- 切换到中文语言，验证上述菜单项、提示与开发版弹窗显示为中文。
- 影响文件
- M locale/lang-zh_CN.js