### PR TITLE
fix the template same name define metaprogramming bug

### DIFF
--- a/src/threads.js
+++ b/src/threads.js
@@ -9558,7 +9558,7 @@ Process.prototype.compileBlockReferences = function (context, varName) {
     }
 
     if (context.expression.allChildren().some(any =>
-        any.selector === 'reportGetVar' && any.parentThatIsA(RingMorph)
+        any.selector === 'reportGetVar' && any.parentThatIsA(RingMorph) && !any.parentThatIsA(TemplateSlotMorph)
     )) {
         if (context.expression instanceof ReporterBlockMorph) {
             // turn into a REPORT script
@@ -9588,7 +9588,7 @@ Process.prototype.compileBlockReferences = function (context, varName) {
         context.expression.forAllChildren(morph => {
             var ref;
             if (morph.selector === 'reportGetVar' &&
-                (morph.blockSpec === varName))
+                (morph.blockSpec === varName) && !(morph.parent instanceof TemplateSlotMorph))
             {
                 ref = block('reportEnvironment');
                 ref.inputs()[0].setContents(['script']);


### PR DESCRIPTION
makes it not replace templates with the same name as the block variable, and nothing else