### PR TITLE
Optimize reportAspect hyperop

### DIFF
--- a/snap.html
+++ b/snap.html
@@ -17,7 +17,7 @@
         <script src="src/symbols.js?version=2024-12-09"></script>
         <script src="src/widgets.js?version=2025-12-19"></script>
         <script src="src/blocks.js?version=2026-01-28"></script>
-        <script src="src/threads.js?version=2026-01-28"></script>
+        <script src="src/threads.js?version=2026-01-29"></script>
         <script src="src/objects.js?version=2026-01-19"></script>
         <script src="src/scenes.js?version=2026-01-04"></script>
         <script src="src/gui.js?version=2026-01-21"></script>

--- a/src/threads.js
+++ b/src/threads.js
@@ -66,7 +66,7 @@ CustomHatBlockMorph*/
 
 /*jshint esversion: 11, bitwise: false, evil: true*/
 
-modules.threads = '2026-January-28';
+modules.threads = '2026-January-29';
 
 var ThreadManager;
 var Process;
@@ -6772,12 +6772,6 @@ Process.prototype.reportAspect = function (aspect, location) {
     // below themselves, not their own color and not colors in sprites above
     // their own layer.
 
-    if (this.enableHyperOps) {
-        if (location instanceof List && !this.isCoordinate(location)) {
-            return location.map(each => this.reportAspect(aspect, each));
-        }
-    }
-
     var choice = this.inputOption(aspect),
         target = this.inputOption(location),
         options = ['hue', 'saturation', 'brightness', 'transparency'],
@@ -6788,6 +6782,35 @@ Process.prototype.reportAspect = function (aspect, location) {
         world = thisObj.world(),
         point,
         clr;
+
+    if (this.enableHyperOps) {
+        if (location instanceof List && !this.isCoordinate(location)) {
+            if (choice === "sprites") return location.map(each => this.reportAspect(aspect, each));
+
+            var ctx = Morph.prototype.fullImage.call(world)
+                        .getContext('2d');
+
+            return location.map(each => {
+                var data = ctx.getImageData(each.at(1), each.at(2), 1, 1)
+                            .data,
+                    clr = new Color(data[0], data[1], data[2]);
+                
+                if (choice === 'color') {
+                    return clr.copy();
+                }
+                if (choice === 'r-g-b-a') {
+                    return new List([clr.r, clr.g, clr.b, Math.round(clr.a * 255)]);
+                }
+                if (idx < 0 || idx > 3) {
+                    return;
+                }
+                if (idx === 3) {
+                    return (1 - clr.a) * 100;
+                }
+                return clr[SpriteMorph.prototype.penColorModel]()[idx] * 100;
+            });
+        }
+    }
 
     if (target === 'myself') {
         if (choice === 'sprites') {


### PR DESCRIPTION
From [Speed up “aspect” reporter for hyper inputs](https://forum.snap.berkeley.edu/t/speed-up-aspect-reporter-for-hyper-inputs/21325/8) on the forums
Hope this gets pushed, because it is possible to scan the entire stage with this! (there should, in my opinion, be a "stage pic" extension? There might already be one but I dont know..)