### PR TITLE
fix: use Element.remove() in importLocalFile to avoid removeChild errors

### DIFF
--- a/src/gui.js
+++ b/src/gui.js
@@ -3098,7 +3098,7 @@ IDE_Morph.prototype.reactToWorldResize = function (rect) {
         this.setExtent(rect.extent());
     }
     if (this.filePicker) {
-        document.body.removeChild(this.filePicker);
+        this.filePicker.remove();
         this.filePicker = null;
         this.isImportingLocalFile = false;
     }
@@ -5644,7 +5644,7 @@ IDE_Morph.prototype.importLocalFile = function () {
         world = this.world();
 
     if (this.filePicker) {
-        document.body.removeChild(this.filePicker);
+        this.filePicker.remove();
         this.filePicker = null;
     }
     inp.type = 'file';
@@ -5661,7 +5661,7 @@ IDE_Morph.prototype.importLocalFile = function () {
     inp.addEventListener(
         "change",
         () => {
-            document.body.removeChild(inp);
+            inp.remove();
             this.filePicker = null;
             if (addingScenes) {
                 myself.isAddingNextScene = true;


### PR DESCRIPTION
I first thougt it's a bug in TurtleStitch, but then same happened in current Snap! version: I could not load local project files via the open dialog (while drag and drop worked). But it also seemed impossible this bug to not be spotted for months!

Meanwhile I think this is and edge case caused by me experimenting and running a tiled window mangaer (and the open dialog does not open up as a dialog but in another window which causes the windows to be re-arranged and resized, which in turn causes the browser to send a resize event the same time or just before the file is loaded, triggering the error which is best decribed here by Claude (who found that bug for me):

<snip>

 In some browsers/OS combinations, opening the native file dialog triggers a   window-resize event. `reactToWorldResize` responds by calling   `document.body.removeChild(this.filePicker)` and nulling the reference.

  When the user subsequently picks a file, the `change` listener fires and   calls `document.body.removeChild(inp)` — but `inp` was already removed,   producing:

  > Uncaught DOMException: Node.removeChild: The node to be removed is not a child of this node

  The same race can affect the guard at the top of `importLocalFile` if a   stale `this.filePicker` reference somehow survives.

  The root cause is the change handler one — reactToWorldResize strips inp from the DOM before
  the handler runs. The other two are defensive cleanups.

</snip>

so this fixes that edge case!