### PR TITLE
Fix potential undefined reference to window.parent in TuneScope.js

### DIFF
--- a/libraries/TuneScope/TuneScope.js
+++ b/libraries/TuneScope/TuneScope.js
@@ -1,7 +1,9 @@
 SnapExtensions.primitives.set(
     'ts_setinst(name)',
     function (name) {
-        window.parent.currentInstrumentName = name.toLowerCase();
+        if (window.parent) {
+            window.parent.currentInstrumentName = name.toLowerCase();
+        }
     }
 );
 
@@ -9,7 +11,9 @@ SnapExtensions.primitives.set(
     'ts_setvol(percent)',
     function (percent) {
         let adjusted_percent = (percent === 0) ? 0.0001: percent;
-        window.parent.globalInstrumentVolume = adjusted_percent/100.0;
+        if (window.parent) {
+            window.parent.globalInstrumentVolume = adjusted_percent/100.0;
+        }
     }
 );
 
@@ -18,7 +22,9 @@ SnapExtensions.primitives.set(
     function (name, percent) {
         name = name.toLowerCase();
         let adjusted_percent = (percent === 0) ? 0.0001: percent;
-        window.parent.instrumentVolumes[name] = adjusted_percent/100.0;
+        if (window.parent) {
+            window.parent.instrumentVolumes[name] = adjusted_percent/100.0;
+        }
     }
 );
 


### PR DESCRIPTION
The TuneScope.js initialization code (TS_init.js) defines several functions and objects intended for cross-frame communication via window.parent, but TuneScope.js directly accesses window.parent without checking if the script is running in an iframe. When loaded directly (not in an iframe), window.parent references the current window, but subsequent accesses like window.parent.midiPitches assume a parent context that may not exist. This change adds a guard in TuneScope.js to ensure window.parent is defined and accessible before accessing its properties, preventing runtime errors when the script runs outside of an iframe.