### PR TITLE
forcing fixLayout to skip loadingByURL problems

### DIFF
--- a/src/gui.js
+++ b/src/gui.js
@@ -7291,7 +7291,8 @@ IDE_Morph.prototype.switchToScene = function (
     scene.applyGlobalSettings();
     this.selectSprite(this.scene.currentSprite, true);
     this.corral.album.updateSelection();
-    this.hideSpritePanes(this.scene.hideSprites); // this.fixLayout();
+    this.hideSpritePanes(this.scene.hideSprites);
+    this.fixLayout();
     this.corral.album.contents.children.forEach(function (morph) {
         if (morph.state) {
             morph.scrollIntoView();


### PR DESCRIPTION
Hi Jens.

This is the issue we were talking by mail.

The origin is [a commit on February 18](https://github.com/jmoenig/Snap/ commit/519a8b5d17b50bf1aa00f80f84b3923d2b01829b). It seems right, because the `hideSpritePanes` is already fixing the Layout... but you know asynchronous processes they give us surprises :)

I think this fix is not doing nothing wrong... and I've tested and it fix the problem I see in some scenarios (like the Moodle plugin loader).

Joan