### PR TITLE
fix some issues with bignums

### DIFF
--- a/libraries/bignums.js
+++ b/libraries/bignums.js
@@ -102,16 +102,15 @@ function loadBlocks (useBigNums) {
     if (useBigNums) {
         InputSlotMorph.prototype.evaluate = function () {
             var contents = this.contents();
-
+            
             if (this.selectedBlock) {
-                    return this.selectedBlock;
+                return this.selectedBlock;
             }
-
             if (this.constant) {
                 return this.constant;
             }
             if (this.isNumeric) {
-                return parseNumber(contents.text || '0');
+                return isNaN(Number(contents.text))?contents.text:parseNumber(contents.text || '0');
             }
             return contents.text;
         };
@@ -120,8 +119,8 @@ function loadBlocks (useBigNums) {
                 value,
                 newValue;
             if (frame) {
-                value = parseNumber(frame.vars[name].value);
-                newValue = Number.isNaN(value) ? delta : fn['+'](value, parseNumber(delta));
+                value = frame.vars[name].value;
+                newValue = Process.prototype.reportSum(value,delta);
                 if (sender instanceof SpriteMorph &&
                         (frame.owner instanceof SpriteMorph) &&
                         (sender !== frame.owner)) {


### PR DESCRIPTION
there were some issues with hyperops on changeby and accessing

# before
<img width="272" height="29" alt="Untitled script pic(37)" src="https://github.com/user-attachments/assets/df0ec0ff-7830-4f17-8d66-83ab5474b90f" />
<img width="264" height="95" alt="Untitled script pic(39)" src="https://github.com/user-attachments/assets/5495ab9d-f765-4d4a-9dfa-0277d474fdf3" />

# after
<img width="349" height="85" alt="Untitled script pic(38)" src="https://github.com/user-attachments/assets/07fb2384-31f3-44b6-8fd1-6d54db99e9e5" />
<img width="335" height="205" alt="wasm_new script pic" src="https://github.com/user-attachments/assets/2c9ab468-8bbc-43a7-8a70-7ea205cf4075" />

the gray list is from a userscript displaying a selector as a list