### PR TITLE
Add a noStorageItems config option 

### DIFF
--- a/src/gui.js
+++ b/src/gui.js
@@ -274,6 +274,7 @@ function IDE_Morph(config = {}) {
         hideCategories: bool, hide/show the palette block category buttons
         hideProjectName:bool, hide/show the project title in the tool bar
         noProjectItems: bood, hide/show project specific menu items
+        noStorageItems: bool, hide/show only the load/save menu items
         noDefaultCat:   bool, hide/show the buit-in bloc category buttons
         noSpriteEdits:  bool, hide/show the corral & sprite controls/menus
         noSprites:      bool, hide/show the stage, corral, sprite editor
@@ -5065,27 +5066,34 @@ IDE_Morph.prototype.projectMenu = function () {
     menu.addItem('Notes...', 'editNotes');
     menu.addLine();
     if (!this.config.noProjectItems) {
-        menu.addPair('New', 'createNewProject', '^N');
-        menu.addPair('Open...', 'openProjectsBrowser', '^O');
-        menu.addPair('Save', "save", '^S');
-        menu.addItem('Save As...', 'saveProjectsBrowser');
-        if (backup) {
-            menu.addItem(
-                'Restore unsaved project',
-                'restore',
-                backup,
-                shiftClicked ? new Color(100, 0, 0) : null
-            );
-            if (shiftClicked) {
+        // Setting noProjectItems removes a bunch of things from the project
+        // menu. This flag enables a more selective disabling of just the menu
+        // items that deal with the Snap! storage system. This is useful for
+        // embedding Snap! in a site that manages saving and loading the
+        // project.xml itself.
+        if (!this.config.noStorageItems) {
+            menu.addPair('New', 'createNewProject', '^N');
+            menu.addPair('Open...', 'openProjectsBrowser', '^O');
+            menu.addPair('Save', "save", '^S');
+            menu.addItem('Save As...', 'saveProjectsBrowser');
+            if (backup) {
                 menu.addItem(
-                    'Clear backup',
-                    'clearBackup',
+                    'Restore unsaved project',
+                    'restore',
                     backup,
-                    new Color(100, 0, 0)
+                    shiftClicked ? new Color(100, 0, 0) : null
                 );
+                if (shiftClicked) {
+                    menu.addItem(
+                        'Clear backup',
+                        'clearBackup',
+                        backup,
+                        new Color(100, 0, 0)
+                    );
+                }
             }
+            menu.addLine();
         }
-        menu.addLine();
         menu.addItem(
             'Import...',
             'importLocalFile',


### PR DESCRIPTION
This is a counterpart to `noProjectItems` that removes only those items from the project menu that are specifically related to storage and retrieval of the project.xml file. I'm working on embedding Snap! in my own class website where I store student work in Github so I want to disable the storage related UI but keep the rest.

Happy to discuss if there's a better way to wire this in or if there is any reason this doesn't fit with your goals for Snap! (I looked for somewhere to discuss this first on the Snap! forums but didn't see a category for Snap! development.)

P.S. Hi Jens, I've been away for about four years. Don't know if you recall but I submitted two tiny PRs back in 2022 when I was volunteering in an AP CSP class. Now I'm about to start my fifth year as a teacher and will be teaching CSP next year for the first time. So this probably isn't the last time you'll hear from me. ;-) 