### PR TITLE
Skip cloud session init at startup when config.noCloud is set

### DIFF
--- a/src/gui.js
+++ b/src/gui.js
@@ -846,7 +846,10 @@ IDE_Morph.prototype.openIn = function (world) {
 
     if (location.protocol === 'file:') {
         Process.prototype.enableJS = true;
-    } else {
+    } else if (!this.config.noCloud) {
+        // honor config.noCloud here at startup: applyConfigurations() below
+        // does disable the cloud, but only after these requests would
+        // already have been sent
         if (!sessionStorage.username) {
             // check whether login should persist across browser sessions
             this.cloud.initSession(initUser);


### PR DESCRIPTION
Maybe not a huge issue but I was getting errors in the console on my embedded Snap. Claude helped me diagnose what was going on and suggested this patch which I've tested on my site and seems to work.