### PR TITLE
Restore palette after getting project XML.

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -237,7 +237,18 @@ IDE_Morph.prototype.newList = function (array) {
 };
 
 IDE_Morph.prototype.getProjectXML = function () {
-    return this.serializer.serialize(new Project(this.scenes, this.scene));
+    // bracket the serialization in capture/applyGlobalSettings the way
+    // exportProject() does: Scene.toXML ends by assigning the bootstrapped
+    // customized-primitives *array* to SpriteMorph.prototype.blocks,
+    // clobbering the primitives dictionary (to an empty array when no
+    // primitive is customized), which silently breaks block search and any
+    // subsequent palette rebuild; applyGlobalSettings() restores the
+    // dictionary afterwards
+    var xml;
+    this.scene.captureGlobalSettings();
+    xml = this.serializer.serialize(new Project(this.scenes, this.scene));
+    this.scene.applyGlobalSettings();
+    return xml;
 };
 
 IDE_Morph.prototype.loadProjectXML = function (projectXML) {


### PR DESCRIPTION
Another one Claude helped me debug. In my embedded Snap I have it set up to autosave and after autosaving the palette search box no longer worked. This patch seems to fix that. There may be a better place to do this so that both paths that need this restoration get it but this is the simple change that fixes the immediate bug.