### PR TITLE
Add 'clean unhatted' scripts-pane menu item

### DIFF
--- a/src/blocks.js
+++ b/src/blocks.js
@@ -9224,6 +9224,11 @@ ScriptsMorph.prototype.userMenu = function () {
     }
 
     menu.addItem('clean up', 'cleanUp', 'arrange scripts\nvertically');
+    menu.addItem(
+        'clean unhatted',
+        'cleanUnhatted',
+        'arrange scripts vertically,\nremoving all scripts\nnot attached to a hat block'
+    );
     menu.addItem('add comment', 'addComment');
     menu.addItem(
         'scripts pic...',
@@ -9296,6 +9301,30 @@ ScriptsMorph.prototype.cleanUp = function () {
         target.setPosition(target.parent.topLeft());
     }
     target.adjustBounds();
+};
+
+ScriptsMorph.prototype.cleanUnhatted = function () {
+    // delete all scripts not attached to a hat block,
+    // then arrange the remaining scripts vertically
+    var target = this.selectForEdit(), // enable copy-on-edit
+        ide = target.parentThatIsA(IDE_Morph);
+    target.children.filter(child =>
+        child instanceof BlockMorph && !(child instanceof HatBlockMorph)
+    ).forEach(block => {
+        // for undrop / redrop
+        target.clearDropInfo();
+        target.lastDroppedBlock = block;
+        target.recordDrop(block.situation());
+        target.dropRecord.action = 'delete';
+
+        if (ide) {
+            // also stop any processes currently running this script
+            ide.removeBlock(block);
+        } else {
+            block.destroy();
+        }
+    });
+    target.cleanUp();
 };
 
 ScriptsMorph.prototype.exportScriptsPicture = function () {


### PR DESCRIPTION
This is a feature I've wanted for a long time: like 'clean up', but it first deletes all loose blocks, i.e. blocks not attached to some hat. Deletions go through the normal drop-record path so each one is undoable, and through IDE_Morph.removeBlock so any processes running those scripts are stopped. I'm not tied to the name. `clean loose` might be more clear in some sense? And maybe easier to translate into other languages?