### PR TITLE
Slight improvement to click-to-edit UI

### DIFF
--- a/src/blocks.js
+++ b/src/blocks.js
@@ -6080,13 +6080,13 @@ BlockMorph.prototype.pickUp = function (wrrld) {
 
 // BlockMorph events
 
-BlockMorph.prototype.mouseClickLeft = function () {
+BlockMorph.prototype.mouseClickLeft = function (pos) {
     var top = this.topBlock(),
         receiver = top.scriptTarget(),
         shiftClicked = this.world().currentKey === 16,
         stage;
     if (shiftClicked && !this.isTemplate) {
-        return this.selectForEdit().focus(); // enable copy-on-edit
+        return this.selectForEdit().focus(pos); // enable copy-on-edit
     }
     if (top instanceof PrototypeHatBlockMorph) {
         return; // top.mouseClickLeft();
@@ -6099,7 +6099,9 @@ BlockMorph.prototype.mouseClickLeft = function () {
     }
 };
 
-BlockMorph.prototype.focus = function () {
+BlockMorph.prototype.focus = function (pos) {
+    // if the click position is given and lies in my lower half,
+    // place the focus below me rather than above
     var scripts = this.parentThatIsA(ScriptsMorph),
         world = this.world(),
         focus;
@@ -6110,6 +6112,9 @@ BlockMorph.prototype.focus = function () {
     scripts.focus = focus;
     focus.getFocus(world);
     if (this instanceof HatBlockMorph) {
+        focus.nextCommand();
+    } else if (pos && this instanceof CommandBlockMorph &&
+            pos.y > this.center().y) {
         focus.nextCommand();
     }
 };
@@ -9811,14 +9816,46 @@ ScriptsMorph.prototype.droppedImage = function (aCanvas, name, embeddedData) {
 // ScriptsMorph keyboard support
 
 ScriptsMorph.prototype.edit = function (pos) {
-    var target,
+    var target, block,
 		world = this.world();
     if (this.focus) {this.focus.stopEditing(); }
     world.stopEditing();
     if (!ScriptsMorph.prototype.enableKeyboard) {return; }
     target = this.selectForEdit(); // enable copy-on-edit
-    target.focus = new ScriptFocusMorph(target, target, pos);
+    block = target.bottomBlockNear(pos);
+    if (block) {
+        target.focus = new ScriptFocusMorph(target, block);
+        target.focus.atEnd = true;
+    } else {
+        target.focus = new ScriptFocusMorph(target, target, pos);
+    }
     target.focus.getFocus(world);
+};
+
+ScriptsMorph.prototype.bottomBlockNear = function (pos) {
+    // answer the bottom block of a script whose bottom edge is close
+    // enough above pos for the keyboard focus to attach to it,
+    // or null if there is none
+    var thresh = Math.max(
+            SyntaxElementMorph.prototype.corner * 2 +
+                SyntaxElementMorph.prototype.dent,
+            SyntaxElementMorph.prototype.minSnapDistance
+        ),
+        answer = null,
+        best = thresh;
+    this.children.forEach(morph => {
+        var block, dist;
+        if (morph instanceof CommandBlockMorph) {
+            block = morph.bottomBlock();
+            dist = pos.y - block.bottom();
+            if (dist >= 0 && dist < best && !block.isStop() &&
+                    pos.x >= block.left() && pos.x <= block.right()) {
+                best = dist;
+                answer = block;
+            }
+        }
+    });
+    return answer;
 };
 
 ScriptsMorph.prototype.toggleKeyboardEntry = function () {
@@ -17330,7 +17367,11 @@ CommentMorph.prototype.stackHeight = function () {
 
     activate:
       - shift + click on a scripting pane's background
+        (if the click is close below the end of a script the focus
+        attaches to that script's bottom, otherwise it floats freely)
       - shift + click on any block
+        (clicking a command block's lower half places the focus below
+        the block, clicking its upper half places it above)
       - shift + enter in the IDE's edit mode
 
     stop editing:

--- a/src/blocks.js
+++ b/src/blocks.js
@@ -9816,7 +9816,7 @@ ScriptsMorph.prototype.droppedImage = function (aCanvas, name, embeddedData) {
 // ScriptsMorph keyboard support
 
 ScriptsMorph.prototype.edit = function (pos) {
-    var target, block, slot,
+    var target, block, slot, end,
         below = false,
 		world = this.world();
     if (this.focus) {this.focus.stopEditing(); }
@@ -9838,10 +9838,10 @@ ScriptsMorph.prototype.edit = function (pos) {
             target.focus = new ScriptFocusMorph(target, slot);
         }
     } else {
-        block = target.bottomBlockNear(pos);
-        if (block) {
-            target.focus = new ScriptFocusMorph(target, block);
-            target.focus.atEnd = true;
+        end = target.scriptEndNear(pos);
+        if (end) {
+            target.focus = new ScriptFocusMorph(target, end.block);
+            target.focus.atEnd = end.atEnd;
         } else {
             target.focus = new ScriptFocusMorph(target, target, pos);
         }
@@ -9869,10 +9869,13 @@ ScriptsMorph.prototype.cSlotAt = function (pos) {
     return answer;
 };
 
-ScriptsMorph.prototype.bottomBlockNear = function (pos) {
-    // answer the bottom block of a script whose bottom edge is close
-    // enough above pos for the keyboard focus to attach to it,
-    // or null if there is none
+ScriptsMorph.prototype.scriptEndNear = function (pos) {
+    // answer the block at whichever end of a script - top or bottom -
+    // is closest to pos, if that end is close enough for the keyboard
+    // focus to attach to it, or null if there is none. The answer is
+    // an object {block, atEnd} matching the focus's attachment state:
+    // {bottom block, true} below a script's end, {top block, false}
+    // above a script's beginning.
     var thresh = Math.max(
             SyntaxElementMorph.prototype.corner * 2 +
                 SyntaxElementMorph.prototype.dent,
@@ -9888,7 +9891,14 @@ ScriptsMorph.prototype.bottomBlockNear = function (pos) {
             if (dist >= 0 && dist < best && !block.isStop() &&
                     pos.x >= block.left() && pos.x <= block.right()) {
                 best = dist;
-                answer = block;
+                answer = {block: block, atEnd: true};
+            }
+            dist = morph.top() - pos.y;
+            if (dist >= 0 && dist < best &&
+                    !(morph instanceof HatBlockMorph) &&
+                    pos.x >= morph.left() && pos.x <= morph.right()) {
+                best = dist;
+                answer = {block: morph, atEnd: false};
             }
         }
     });
@@ -17405,8 +17415,8 @@ CommentMorph.prototype.stackHeight = function () {
     activate:
       - shift + click on a scripting pane's background
         (if the click is inside a C-slot the focus attaches inside it,
-        if it is close below the end of a script the focus attaches to
-        that script's bottom, otherwise it floats freely)
+        if it is close to either end of a script the focus attaches to
+        that script's bottom or top, otherwise it floats freely)
       - shift + click on any block
         (clicking a command block's lower half places the focus below
         the block, clicking its upper half places it above)

--- a/src/blocks.js
+++ b/src/blocks.js
@@ -10150,6 +10150,22 @@ ArgMorph.prototype.reactToSliderEdit = function () {
     }
 };
 
+ArgMorph.prototype.focus = function () {
+    // attach the keyboard focus to me, so a block entered at it lands
+    // in my slot; answer the focus, or null if I'm not in a scripting
+    // pane open to keyboard editing
+    var scripts = this.parentThatIsA(ScriptsMorph),
+        world = this.world(),
+        focus;
+    if (!scripts || !ScriptsMorph.prototype.enableKeyboard) {return null; }
+    if (scripts.focus) {scripts.focus.stopEditing(); }
+    world.stopEditing();
+    focus = new ScriptFocusMorph(scripts, this);
+    scripts.focus = focus;
+    focus.getFocus(world);
+    return focus;
+};
+
 ArgMorph.prototype.setContents = function () {
     // subclass responsibility
     nop();
@@ -13007,6 +13023,14 @@ InputSlotMorph.prototype.fixLayout = function () {
 // InputSlotMorph events:
 
 InputSlotMorph.prototype.mouseDownLeft = function (pos) {
+    var cursor = this.root().cursor;
+    if (this.world().currentKey === 16 &&
+            !(cursor && cursor.target === this.contents())) {
+        // shift-click: wait for the mouse up, which attaches the
+        // keyboard focus to me instead of editing my contents, unless
+        // I'm already being edited - then extend the selection as usual
+        return;
+    }
     if (this.isReadOnly || this.symbol ||
             this.arrow().bounds.containsPoint(pos)) {
         this.escalateEvent('mouseDownLeft', pos);
@@ -13016,6 +13040,10 @@ InputSlotMorph.prototype.mouseDownLeft = function (pos) {
 };
 
 InputSlotMorph.prototype.mouseClickLeft = function (pos) {
+    if (this.world().currentKey === 16 && // shift-clicked
+            this.selectForEdit().focus()) {
+        return;
+    }
     if (this.arrow().bounds.containsPoint(pos)) {
         this.dropDownMenu();
     } else if (this.isReadOnly || this.symbol) {
@@ -13334,6 +13362,21 @@ InputSlotStringMorph.prototype.getShadowRenderColor = function () {
     return this.parent.alpha > 0.25 ? this.shadowColor : CLEAR;
 };
 
+InputSlotStringMorph.prototype.mouseClickLeft = function (pos) {
+    // shift-click: attach the keyboard focus to my slot, unless I'm
+    // the text currently being edited - then extend the selection to
+    // the click as usual
+    var cursor = this.root().cursor,
+        slot = this.parentThatIsA(InputSlotMorph);
+    if (this.world().currentKey === 16 &&
+            !(cursor && cursor.target === this) &&
+            slot &&
+            slot.selectForEdit().focus()) {
+        return;
+    }
+    StringMorph.prototype.mouseClickLeft.call(this, pos);
+};
+
 // InputSlotTextMorph ///////////////////////////////////////////////
 
 /*
@@ -13376,6 +13419,9 @@ InputSlotTextMorph.prototype.getRenderColor =
 
 InputSlotTextMorph.prototype.getShadowRenderColor =
     InputSlotStringMorph.prototype.getShadowRenderColor;
+
+InputSlotTextMorph.prototype.mouseClickLeft =
+    InputSlotStringMorph.prototype.mouseClickLeft;
 
 // TemplateSlotMorph ///////////////////////////////////////////////////
 
@@ -13790,6 +13836,10 @@ BooleanSlotMorph.prototype.nextValue = function () {
 // BooleanSlotMorph events:
 
 BooleanSlotMorph.prototype.mouseClickLeft = function () {
+    if (this.world().currentKey === 16 && // shift-clicked
+            this.selectForEdit().focus()) {
+        return;
+    }
     this.toggleValue();
     if (isNil(this.value)) {return; }
     this.reactToSliderEdit();
@@ -14546,6 +14596,10 @@ ColorSlotMorph.prototype.getUserColor = function () {
 // ColorSlotMorph events:
 
 ColorSlotMorph.prototype.mouseClickLeft = function () {
+    if (this.world().currentKey === 16 && // shift-clicked
+            this.selectForEdit().focus()) {
+        return;
+    }
     this.selectForEdit().getUserColor();
 };
 

--- a/src/blocks.js
+++ b/src/blocks.js
@@ -9816,20 +9816,57 @@ ScriptsMorph.prototype.droppedImage = function (aCanvas, name, embeddedData) {
 // ScriptsMorph keyboard support
 
 ScriptsMorph.prototype.edit = function (pos) {
-    var target, block,
+    var target, block, slot,
+        below = false,
 		world = this.world();
     if (this.focus) {this.focus.stopEditing(); }
     world.stopEditing();
     if (!ScriptsMorph.prototype.enableKeyboard) {return; }
     target = this.selectForEdit(); // enable copy-on-edit
-    block = target.bottomBlockNear(pos);
-    if (block) {
-        target.focus = new ScriptFocusMorph(target, block);
-        target.focus.atEnd = true;
+    slot = target.cSlotAt(pos);
+    if (slot) {
+        block = slot.nestedBlock();
+        if (block) {
+            // attach the focus to the nested script's command at the
+            // click's height, above or below it depending on the half
+            while (block.nextBlock() && pos.y > block.bottom()) {
+                block = block.nextBlock();
+            }
+            target.focus = new ScriptFocusMorph(target, block);
+            below = pos.y > block.center().y;
+        } else {
+            target.focus = new ScriptFocusMorph(target, slot);
+        }
     } else {
-        target.focus = new ScriptFocusMorph(target, target, pos);
+        block = target.bottomBlockNear(pos);
+        if (block) {
+            target.focus = new ScriptFocusMorph(target, block);
+            target.focus.atEnd = true;
+        } else {
+            target.focus = new ScriptFocusMorph(target, target, pos);
+        }
     }
     target.focus.getFocus(world);
+    if (below) {
+        target.focus.nextCommand();
+    }
+};
+
+ScriptsMorph.prototype.cSlotAt = function (pos) {
+    // answer the innermost C-slot whose interior lies under pos, or
+    // null if there is none. A C-slot's interior is a hit-detection
+    // "hole", so clicks inside it fall through to the scripting pane -
+    // this test mirrors Morph.topMorphAt's hole test.
+    var answer = null;
+    this.allChildren().forEach(morph => {
+        if (morph instanceof CSlotMorph &&
+                morph.holes.some(hole =>
+                    hole.translateBy(morph.position()).containsPoint(pos))
+        ) {
+            answer = morph; // preorder: a later match is nested deeper
+        }
+    });
+    return answer;
 };
 
 ScriptsMorph.prototype.bottomBlockNear = function (pos) {
@@ -17367,8 +17404,9 @@ CommentMorph.prototype.stackHeight = function () {
 
     activate:
       - shift + click on a scripting pane's background
-        (if the click is close below the end of a script the focus
-        attaches to that script's bottom, otherwise it floats freely)
+        (if the click is inside a C-slot the focus attaches inside it,
+        if it is close below the end of a script the focus attaches to
+        that script's bottom, otherwise it floats freely)
       - shift + click on any block
         (clicking a command block's lower half places the focus below
         the block, clicking its upper half places it above)

--- a/src/objects.js
+++ b/src/objects.js
@@ -5065,6 +5065,56 @@ SpriteMorph.prototype.searchBlocks = function (
         selection,
         focus;
 
+    function makeClickHandler(block) {
+        // clicking anywhere on a block inserts it at the focus, same as
+        // selecting it with the arrow keys and pressing enter, instead of
+        // the palette's normal click behaviors (run the block, edit a
+        // slot, expand a multi-arg)
+        var handler = function () {
+            selection = block;
+            searchPane.accept();
+        };
+        handler.isSearchClickHandler = true;
+        return handler;
+    }
+
+    function removeClickHandlers(block) {
+        // strip the search-pane handlers off a block leaving the pane
+        // (inserted at the focus, or grabbed by the hand) so they don't
+        // shadow its normal behaviors in the scripting area
+        block.allChildren().forEach(morph =>
+            ['mouseClickLeft', 'prepareToBeGrabbed'].forEach(prop => {
+                if (morph[prop] && morph[prop].isSearchClickHandler) {
+                    delete morph[prop];
+                }
+            })
+        );
+    }
+
+    function makeClickable(block) {
+        block.allChildren().forEach(morph => {
+            if (morph.mouseClickLeft &&
+                !Object.prototype.hasOwnProperty.call(
+                    morph,
+                    'mouseClickLeft'
+                )
+            ) {
+                morph.mouseClickLeft = makeClickHandler(block);
+            }
+        });
+        // dragging is still possible; clean up the grabbed morph, which
+        // is a copy of the block if it is a template (a copy shares the
+        // block's own properties, including these handlers) or else the
+        // block itself
+        block.prepareToBeGrabbed = function (hand) {
+            removeClickHandlers(this); // also removes this override
+            if (this.prepareToBeGrabbed) {
+                this.prepareToBeGrabbed(hand);
+            }
+        };
+        block.prepareToBeGrabbed.isSearchClickHandler = true;
+    }
+
     function showSelection() {
         if (focus) {focus.destroy(); }
         if (!selection || !scriptFocus) {return; }
@@ -5072,7 +5122,10 @@ SpriteMorph.prototype.searchBlocks = function (
             IDE_Morph.prototype.isBright ? new Color(150, 200, 255) : WHITE,
             2
         );
+        // the outline hit-tests as a rectangle covering the whole
+        // selected block, so route clicks and grabs on it to the block
         focus.mouseClickLeft = () => searchPane.accept();
+        focus.rootForGrab = () => selection;
         searchPane.contents.add(focus);
         focus.scrollIntoView();
     }
@@ -5090,18 +5143,7 @@ SpriteMorph.prototype.searchBlocks = function (
             block.setPosition(new Point(x, y));
             searchPane.addContents(block);
             if (scriptFocus) {
-                // clicking anywhere on a block inserts it at the focus,
-                // same as selecting it with the arrow keys and pressing
-                // enter, instead of the palette's normal click behaviors
-                // (run the block, edit a slot, expand a multi-arg)
-                block.allChildren().forEach(morph => {
-                    if (morph.mouseClickLeft) {
-                        morph.mouseClickLeft = () => {
-                            selection = block;
-                            searchPane.accept();
-                        };
-                    }
-                });
+                makeClickable(block);
             }
             y += block.height();
             y += unit * 0.3;
@@ -5126,6 +5168,7 @@ SpriteMorph.prototype.searchBlocks = function (
         if (scriptFocus) {
             searchBar.cancel();
             if (selection) {
+                removeClickHandlers(selection);
                 scriptFocus.insertBlock(selection);
             }
             myself.recordUserEdit(

--- a/src/objects.js
+++ b/src/objects.js
@@ -5072,6 +5072,7 @@ SpriteMorph.prototype.searchBlocks = function (
             IDE_Morph.prototype.isBright ? new Color(150, 200, 255) : WHITE,
             2
         );
+        focus.mouseClickLeft = () => searchPane.accept();
         searchPane.contents.add(focus);
         focus.scrollIntoView();
     }
@@ -5088,6 +5089,20 @@ SpriteMorph.prototype.searchBlocks = function (
         blocks.forEach(block => {
             block.setPosition(new Point(x, y));
             searchPane.addContents(block);
+            if (scriptFocus) {
+                // clicking anywhere on a block inserts it at the focus,
+                // same as selecting it with the arrow keys and pressing
+                // enter, instead of the palette's normal click behaviors
+                // (run the block, edit a slot, expand a multi-arg)
+                block.allChildren().forEach(morph => {
+                    if (morph.mouseClickLeft) {
+                        morph.mouseClickLeft = () => {
+                            selection = block;
+                            searchPane.accept();
+                        };
+                    }
+                });
+            }
             y += block.height();
             y += unit * 0.3;
         });


### PR DESCRIPTION
It's always frustrated me that there's no way to shift-click and type a block name to add a new block at the bottom of a set of blocks. This PR fixes that.

Shift-clicking a command block's lower half now places the blinking keyboard-entry cursor below the block (between it and any next block) instead of always above it. Shift-clicking the scripting pane's background close beneath the end of a script (within the drag-snap threshold, horizontally within the bottom block) attaches the cursor to that script's end instead of creating a free-floating one.