### PR TITLE
parse %-words as inputs when splitting edited label fragments

### DIFF
--- a/src/byob.js
+++ b/src/byob.js
@@ -1480,7 +1480,13 @@ CustomCommandBlockMorph.prototype.refreshPrototype = function () {
                 );
                 words.forEach(word => {
                     newFrag = part.fragment.copy();
-                    newFrag.labelString = word;
+                    if (word[0] === '%' && word.length > 1) {
+                        // treat as a new input, mirroring labelPart()
+                        newFrag.labelString = word.replace(/%/g, '');
+                        newFrag.type = '%s';
+                    } else {
+                        newFrag.labelString = word;
+                    }
                     frags.push(newFrag);
                 });
             }


### PR DESCRIPTION
It seems that typing `bar %m` into the title-text field of the input-slot dialog (the `+` in the block editor) leaves us in a weird state: It turns `%m` into an input but it's named `%m` instead of `m`: `refreshPrototype` split the multi-word label into plain text fragments, but the rebuilt prototype spec turned the `%m` word into an input morph, which then got the stale text fragment (labelString '%m', type null) assigned to it. 

This PR mirror's `labelPart`'s parsing when splitting: a word starting with `%` becomes an input fragment with the `%` stripped.