### PR TITLE
Dedupe custom block names at creation time

### DIFF
--- a/src/blocks.js
+++ b/src/blocks.js
@@ -9276,11 +9276,20 @@ ScriptsMorph.prototype.userMenu = function () {
                 () => new BlockDialogMorph(
                     null,
                     definition => {
+                        var spec = definition.spec,
+                            count = 1;
                         if (definition.spec !== '') {
                             if (definition.isGlobal) {
                                 stage.globalBlocks.push(definition);
                             } else {
                                 obj.customBlocks.push(definition);
+                            }
+                            // make sure the spec is unique
+                            while (
+                                obj.doubleDefinitionsFor(definition).length > 0
+                            ) {
+                                count += 1;
+                                definition.spec = spec + ' (' + count + ')';
                             }
                             ide.flushPaletteCache();
                             ide.refreshPalette();

--- a/src/objects.js
+++ b/src/objects.js
@@ -4500,11 +4500,18 @@ SpriteMorph.prototype.makeBlock = function () {
     dlg = new BlockDialogMorph(
         null,
         definition => {
+            var spec = definition.spec,
+                count = 1;
             if (definition.spec !== '') {
                 if (definition.isGlobal) {
                     stage.globalBlocks.push(definition);
                 } else {
                     this.customBlocks.push(definition);
+                }
+                // make sure the spec is unique
+                while (this.doubleDefinitionsFor(definition).length > 0) {
+                    count += 1;
+                    definition.spec = spec + ' (' + count + ')';
                 }
                 ide.flushPaletteCache();
                 ide.refreshEmptyCategories();


### PR DESCRIPTION
Currently when you make a block the name doesn't get uniquiefied until the editor is closed. Which means if the project is somehow saved with the editor still open (which can happen on my website where I've embedded Snap!) then the project is saved with multiple blocks with the same name.

This PR changes it so the name is made unique as soon as the block is created. If there's already a `foo` block and you make a new block and name it `foo` it opens in the editor as `foo (2)` which is how it would have been saved later anyway. So this seems strictly better in that it's obvious that you're making a duplicate block as soon as the editor opens.